### PR TITLE
Use IVKs instead of ExtFVKs for creation of payment addresses.

### DIFF
--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -181,7 +181,7 @@ where
         let txs: Vec<WalletTx> = {
             let nf_refs: Vec<_> = nullifiers
                 .iter()
-                .map(|(nf, acc)| (&nf[..], acc.0 as usize))
+                .map(|(nf, acc)| (&nf[..], *acc))
                 .collect();
             let mut witness_refs: Vec<_> = witnesses.iter_mut().map(|w| &mut w.1).collect();
             let ivks: Vec<SaplingIvk> = extfvks.iter().map(|extfvk| extfvk.fvk.vk.ivk()).collect();

--- a/zcash_client_backend/src/data_api/chain.rs
+++ b/zcash_client_backend/src/data_api/chain.rs
@@ -3,7 +3,9 @@ use std::fmt::Debug;
 use zcash_primitives::{
     block::BlockHash,
     consensus::{self, BlockHeight, NetworkUpgrade},
+    primitives::SaplingIvk,
     merkle_tree::CommitmentTree,
+    zip32::ExtendedFullViewingKey,
 };
 
 use crate::{
@@ -150,7 +152,7 @@ where
     })?;
 
     // Fetch the ExtendedFullViewingKeys we are tracking
-    let extfvks = data.get_extended_full_viewing_keys(params)?;
+    let extfvks: Vec<ExtendedFullViewingKey> = data.get_extended_full_viewing_keys(params)?;
 
     // Get the most recent CommitmentTree
     let mut tree = data
@@ -182,10 +184,12 @@ where
                 .map(|(nf, acc)| (&nf[..], acc.0 as usize))
                 .collect();
             let mut witness_refs: Vec<_> = witnesses.iter_mut().map(|w| &mut w.1).collect();
+            let ivks: Vec<SaplingIvk> = extfvks.iter().map(|extfvk| extfvk.fvk.vk.ivk()).collect();
+
             scan_block(
                 params,
                 block,
-                &extfvks[..],
+                &ivks[..],
                 &nf_refs,
                 &mut tree,
                 &mut witness_refs[..],

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -200,6 +200,7 @@ where
         let from = extfvk
             .fvk
             .vk
+            .ivk()
             .to_payment_address(selected.diversifier)
             .unwrap(); //JUBJUB would have to unexpectedly be the zero point for this to be None
 

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -48,7 +48,7 @@ pub fn decrypt_transaction<P: consensus::Parameters>(
             let ((note, to, memo), outgoing) = match try_sapling_note_decryption(
                 params,
                 height,
-                ivk,
+                &ivk.0,
                 &output.ephemeral_key,
                 &output.cmu,
                 &output.enc_ciphertext,

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -1,6 +1,8 @@
 //! Structs representing transaction data scanned from the block chain by a wallet or
 //! light client.
 
+use subtle::{ConditionallySelectable, Choice};
+
 use zcash_primitives::{
     keys::OutgoingViewingKey,
     merkle_tree::IncrementalWitness,
@@ -10,8 +12,14 @@ use zcash_primitives::{
 };
 
 /// A type-safe wrapper for account identifiers.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct AccountId(pub u32);
+
+impl ConditionallySelectable for AccountId {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        AccountId(u32::conditional_select(&a.0, &b.0, choice))
+    }
+}
 
 /// A subset of a [`Transaction`] relevant to wallets and light clients.
 ///
@@ -31,7 +39,7 @@ pub struct WalletTx {
 pub struct WalletShieldedSpend {
     pub index: usize,
     pub nf: Vec<u8>,
-    pub account: usize,
+    pub account: AccountId,
 }
 
 /// A subset of an [`OutputDescription`] relevant to wallets and light clients.

--- a/zcash_primitives/src/primitives.rs
+++ b/zcash_primitives/src/primitives.rs
@@ -52,12 +52,14 @@ pub struct ViewingKey {
     pub nk: jubjub::SubgroupPoint,
 }
 
+pub struct SaplingIvk(pub jubjub::Fr);
+
 impl ViewingKey {
     pub fn rk(&self, ar: jubjub::Fr) -> jubjub::SubgroupPoint {
         self.ak + constants::SPENDING_KEY_GENERATOR * ar
     }
 
-    pub fn ivk(&self) -> jubjub::Fr {
+    pub fn ivk(&self) -> SaplingIvk {
         let mut h = [0; 32];
         h.copy_from_slice(
             Blake2sParams::new()
@@ -73,12 +75,12 @@ impl ViewingKey {
         // Drop the most significant five bits, so it can be interpreted as a scalar.
         h[31] &= 0b0000_0111;
 
-        jubjub::Fr::from_repr(h).expect("should be a valid scalar")
+        SaplingIvk(jubjub::Fr::from_repr(h).expect("should be a valid scalar"))
     }
 
     pub fn to_payment_address(&self, diversifier: Diversifier) -> Option<PaymentAddress> {
         diversifier.g_d().and_then(|g_d| {
-            let pk_d = g_d * self.ivk();
+            let pk_d = g_d * self.ivk().0;
 
             PaymentAddress::from_parts(diversifier, pk_d)
         })

--- a/zcash_primitives/src/primitives.rs
+++ b/zcash_primitives/src/primitives.rs
@@ -52,8 +52,6 @@ pub struct ViewingKey {
     pub nk: jubjub::SubgroupPoint,
 }
 
-pub struct SaplingIvk(pub jubjub::Fr);
-
 impl ViewingKey {
     pub fn rk(&self, ar: jubjub::Fr) -> jubjub::SubgroupPoint {
         self.ak + constants::SPENDING_KEY_GENERATOR * ar
@@ -77,10 +75,14 @@ impl ViewingKey {
 
         SaplingIvk(jubjub::Fr::from_repr(h).expect("should be a valid scalar"))
     }
+}
 
+pub struct SaplingIvk(pub jubjub::Fr);
+
+impl SaplingIvk {
     pub fn to_payment_address(&self, diversifier: Diversifier) -> Option<PaymentAddress> {
         diversifier.g_d().and_then(|g_d| {
-            let pk_d = g_d * self.ivk().0;
+            let pk_d = g_d * self.0;
 
             PaymentAddress::from_parts(diversifier, pk_d)
         })

--- a/zcash_primitives/src/zip32.rs
+++ b/zcash_primitives/src/zip32.rs
@@ -1033,7 +1033,7 @@ mod tests {
             assert_eq!(xfvk.dk.0, tv.dk);
             assert_eq!(xfvk.chain_code.0, tv.c);
 
-            assert_eq!(xfvk.fvk.vk.ivk().to_repr().as_ref(), tv.ivk);
+            assert_eq!(xfvk.fvk.vk.ivk().0.to_repr().as_ref(), tv.ivk);
 
             let mut ser = vec![];
             xfvk.write(&mut ser).unwrap();

--- a/zcash_primitives/src/zip32.rs
+++ b/zcash_primitives/src/zip32.rs
@@ -433,7 +433,7 @@ impl ExtendedFullViewingKey {
             Ok(ret) => ret,
             Err(()) => return Err(()),
         };
-        match self.fvk.vk.to_payment_address(d_j) {
+        match self.fvk.vk.ivk().to_payment_address(d_j) {
             Some(addr) => Ok((j, addr)),
             None => Err(()),
         }

--- a/zcash_proofs/src/circuit/sapling.rs
+++ b/zcash_proofs/src/circuit/sapling.rs
@@ -553,7 +553,7 @@ fn test_input_circuit_with_bls12_381() {
                 Diversifier(d)
             };
 
-            if let Some(p) = viewing_key.to_payment_address(diversifier) {
+            if let Some(p) = viewing_key.ivk().to_payment_address(diversifier) {
                 payment_address = p;
                 break;
             }
@@ -725,7 +725,7 @@ fn test_input_circuit_with_bls12_381_external_test_vectors() {
                 Diversifier(d)
             };
 
-            if let Some(p) = viewing_key.to_payment_address(diversifier) {
+            if let Some(p) = viewing_key.ivk().to_payment_address(diversifier) {
                 payment_address = p;
                 break;
             }
@@ -874,7 +874,7 @@ fn test_output_circuit_with_bls12_381() {
                 Diversifier(d)
             };
 
-            if let Some(p) = viewing_key.to_payment_address(diversifier) {
+            if let Some(p) = viewing_key.ivk().to_payment_address(diversifier) {
                 payment_address = p;
                 break;
             }

--- a/zcash_proofs/src/sapling/prover.rs
+++ b/zcash_proofs/src/sapling/prover.rs
@@ -81,7 +81,7 @@ impl SaplingProvingContext {
         let viewing_key = proof_generation_key.to_viewing_key();
 
         // Construct the payment address with the viewing key / diversifier
-        let payment_address = viewing_key.to_payment_address(diversifier).ok_or(())?;
+        let payment_address = viewing_key.ivk().to_payment_address(diversifier).ok_or(())?;
 
         // This is the result of the re-randomization, we compute it for the caller
         let rk =


### PR DESCRIPTION
This is a minor refactoring to make it easier to construct IVK-only wallets.

This will be retargeted to `master` once the `data_access_api` branch merges.