### PR TITLE
zcash_client_backend: Require the tree state for the start of each sc…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,8 +1087,7 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361c467824d4d9d4f284be4b2608800839419dccc4d4608f28345237fe354623"
+source = "git+https://github.com/nuttycom/incrementalmerkletree?rev=fa147c89c6c98a03bba745538f4e68d4eaed5146#fa147c89c6c98a03bba745538f4e68d4eaed5146"
 dependencies = [
  "either",
  "proptest",
@@ -1476,8 +1475,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb255c3ffdccd3c84fe9ebed72aef64fdc72e6a3e4180dd411002d47abaad42"
+source = "git+https://github.com/nuttycom/orchard?rev=7ef1feaf1672980095f424be42fd5f79ba01a5aa#7ef1feaf1672980095f424be42fd5f79ba01a5aa"
 dependencies = [
  "aes",
  "bitvec",
@@ -2246,8 +2244,7 @@ dependencies = [
 [[package]]
 name = "shardtree"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf20c7a2747d9083092e3a3eeb9a7ed75577ae364896bebbc5e0bdcd4e97735"
+source = "git+https://github.com/nuttycom/incrementalmerkletree?rev=fa147c89c6c98a03bba745538f4e68d4eaed5146#fa147c89c6c98a03bba745538f4e68d4eaed5146"
 dependencies = [
  "assert_matches",
  "bitflags 2.4.1",
@@ -3056,6 +3053,7 @@ name = "zcash_client_sqlite"
 version = "0.9.1"
 dependencies = [
  "assert_matches",
+ "bls12_381",
  "bs58",
  "byteorder",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,8 @@ zip32 = "0.1"
 lto = true
 panic = 'abort'
 codegen-units = 1
+
+[patch.crates-io]
+incrementalmerkletree = { git = "https://github.com/nuttycom/incrementalmerkletree", rev = "fa147c89c6c98a03bba745538f4e68d4eaed5146" }
+shardtree = { git = "https://github.com/nuttycom/incrementalmerkletree", rev = "fa147c89c6c98a03bba745538f4e68d4eaed5146" }
+orchard = { git = "https://github.com/nuttycom/orchard", rev = "7ef1feaf1672980095f424be42fd5f79ba01a5aa" }

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -67,7 +67,10 @@ use incrementalmerkletree::{frontier::Frontier, Retention};
 use secrecy::SecretVec;
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
 
-use self::{chain::CommitmentTreeRoot, scanning::ScanRange};
+use self::{
+    chain::{ChainState, CommitmentTreeRoot},
+    scanning::ScanRange,
+};
 use crate::{
     address::UnifiedAddress,
     decrypt::DecryptedOutput,
@@ -1260,8 +1263,11 @@ pub trait WalletWrite: WalletRead {
     /// pertaining to this wallet.
     ///
     /// `blocks` must be sequential, in order of increasing block height
-    fn put_blocks(&mut self, blocks: Vec<ScannedBlock<Self::AccountId>>)
-        -> Result<(), Self::Error>;
+    fn put_blocks(
+        &mut self,
+        from_state: &ChainState,
+        blocks: Vec<ScannedBlock<Self::AccountId>>,
+    ) -> Result<(), Self::Error>;
 
     /// Updates the wallet's view of the blockchain.
     ///
@@ -1400,9 +1406,11 @@ pub mod testing {
     };
 
     use super::{
-        chain::CommitmentTreeRoot, scanning::ScanRange, AccountBirthday, BlockMetadata,
-        DecryptedTransaction, InputSource, NullifierQuery, ScannedBlock, SentTransaction,
-        WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, SAPLING_SHARD_HEIGHT,
+        chain::{ChainState, CommitmentTreeRoot},
+        scanning::ScanRange,
+        AccountBirthday, BlockMetadata, DecryptedTransaction, InputSource, NullifierQuery,
+        ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
+        WalletWrite, SAPLING_SHARD_HEIGHT,
     };
 
     #[cfg(feature = "transparent-inputs")]
@@ -1633,6 +1641,7 @@ pub mod testing {
         #[allow(clippy::type_complexity)]
         fn put_blocks(
             &mut self,
+            _from_state: &ChainState,
             _blocks: Vec<ScannedBlock<Self::AccountId>>,
         ) -> Result<(), Self::Error> {
             Ok(())

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -78,10 +78,12 @@ maybe-rayon.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+bls12_381.workspace = true
 incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
 pasta_curves.workspace = true
 shardtree = { workspace = true, features = ["legacy-api", "test-dependencies"] }
 nonempty.workspace = true
+orchard = { workspace = true, features = ["test-dependencies"] }
 proptest.workspace = true
 rand_chacha.workspace = true
 rand_core.workspace = true

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -828,9 +828,9 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                         // Ensure we have a Sapling checkpoint for each checkpointed Orchard block height
                         #[cfg(feature = "orchard")]
                         for (height, checkpoint) in dbg!(&missing_sapling_checkpoints) {
-                            sapling_tree
+                            dbg!(sapling_tree
                                 .store_mut()
-                                .add_checkpoint(*height, checkpoint.clone())
+                                .add_checkpoint(*height, checkpoint.clone()))
                                 .map_err(ShardTreeError::Storage)?;
                         }
 
@@ -856,9 +856,9 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
                         }
 
                         for (height, checkpoint) in dbg!(&missing_orchard_checkpoints) {
-                            orchard_tree
+                            dbg!(orchard_tree
                                 .store_mut()
-                                .add_checkpoint(*height, checkpoint.clone())
+                                .add_checkpoint(*height, checkpoint.clone()))
                                 .map_err(ShardTreeError::Storage)?;
                         }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -32,7 +32,7 @@
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use incrementalmerkletree::Position;
+use incrementalmerkletree::{Position, Retention};
 use maybe_rayon::{
     prelude::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSliceMut,
@@ -58,7 +58,7 @@ use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
         self,
-        chain::{BlockSource, CommitmentTreeRoot},
+        chain::{BlockSource, ChainState, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
         AccountBirthday, BlockMetadata, DecryptedTransaction, InputSource, NullifierQuery,
         ScannedBlock, SentTransaction, WalletCommitmentTrees, WalletRead, WalletSummary,
@@ -75,7 +75,12 @@ use zcash_client_backend::{
 use crate::{error::SqliteClientError, wallet::commitment_tree::SqliteShardStore};
 
 #[cfg(feature = "orchard")]
-use zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT;
+use {
+    incrementalmerkletree::frontier::Frontier,
+    shardtree::store::{Checkpoint, ShardStore},
+    std::collections::BTreeMap,
+    zcash_client_backend::data_api::ORCHARD_SHARD_HEIGHT,
+};
 
 #[cfg(feature = "transparent-inputs")]
 use {
@@ -92,7 +97,6 @@ use {
 
 pub mod chain;
 pub mod error;
-
 pub mod wallet;
 use wallet::{
     commitment_tree::{self, put_shard_roots},
@@ -535,6 +539,7 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
     #[allow(clippy::type_complexity)]
     fn put_blocks(
         &mut self,
+        from_state: &ChainState,
         blocks: Vec<ScannedBlock<Self::AccountId>>,
     ) -> Result<(), Self::Error> {
         struct BlockPositions {
@@ -695,60 +700,166 @@ impl<P: consensus::Parameters> WalletWrite for WalletDb<rusqlite::Connection, P>
             {
                 // Create subtrees from the note commitments in parallel.
                 const CHUNK_SIZE: usize = 1024;
-                {
-                    let sapling_subtrees = sapling_commitments
-                        .par_chunks_mut(CHUNK_SIZE)
-                        .enumerate()
-                        .filter_map(|(i, chunk)| {
-                            let start =
-                                start_positions.sapling_start_position + (i * CHUNK_SIZE) as u64;
-                            let end = start + chunk.len() as u64;
+                let sapling_subtrees = sapling_commitments
+                    .par_chunks_mut(CHUNK_SIZE)
+                    .enumerate()
+                    .filter_map(|(i, chunk)| {
+                        let start =
+                            start_positions.sapling_start_position + (i * CHUNK_SIZE) as u64;
+                        let end = start + chunk.len() as u64;
 
-                            shardtree::LocatedTree::from_iter(
-                                start..end,
-                                SAPLING_SHARD_HEIGHT.into(),
-                                chunk.iter_mut().map(|n| n.take().expect("always Some")),
-                            )
+                        shardtree::LocatedTree::from_iter(
+                            start..end,
+                            SAPLING_SHARD_HEIGHT.into(),
+                            chunk.iter_mut().map(|n| n.take().expect("always Some")),
+                        )
+                    })
+                    .map(|res| (res.subtree, res.checkpoints))
+                    .collect::<Vec<_>>();
+
+                #[cfg(feature = "orchard")]
+                let orchard_subtrees = orchard_commitments
+                    .par_chunks_mut(CHUNK_SIZE)
+                    .enumerate()
+                    .filter_map(|(i, chunk)| {
+                        let start =
+                            start_positions.orchard_start_position + (i * CHUNK_SIZE) as u64;
+                        let end = start + chunk.len() as u64;
+
+                        shardtree::LocatedTree::from_iter(
+                            start..end,
+                            ORCHARD_SHARD_HEIGHT.into(),
+                            chunk.iter_mut().map(|n| n.take().expect("always Some")),
+                        )
+                    })
+                    .map(|res| (res.subtree, res.checkpoints))
+                    .collect::<Vec<_>>();
+
+                // Collect the complete set of Sapling checkpoints
+                #[cfg(feature = "orchard")]
+                let sapling_checkpoint_positions: BTreeMap<BlockHeight, Position> =
+                    dbg!(sapling_subtrees
+                        .iter()
+                        .flat_map(|(_, checkpoints)| checkpoints.iter())
+                        .map(|(k, v)| (*k, *v))
+                        .collect());
+
+                #[cfg(feature = "orchard")]
+                let orchard_checkpoint_positions: BTreeMap<BlockHeight, Position> =
+                    dbg!(orchard_subtrees
+                        .iter()
+                        .flat_map(|(_, checkpoints)| checkpoints.iter())
+                        .map(|(k, v)| (*k, *v))
+                        .collect());
+
+                #[cfg(feature = "orchard")]
+                fn copy_checkpoints<H, const DEPTH: u8>(
+                    // The set of checkpoints to copy from
+                    from_checkpoint_positions: &BTreeMap<BlockHeight, Position>,
+                    // The set of checkpoints to copy into
+                    to_checkpoint_positions: &BTreeMap<BlockHeight, Position>,
+                    // The frontier whose position will be used when there is no preceding
+                    // checkpoint in to_checkpoint_positions.
+                    state_final_tree: &Frontier<H, DEPTH>,
+                ) -> Vec<(BlockHeight, Checkpoint)> {
+                    from_checkpoint_positions
+                        .keys()
+                        .flat_map(|from_checkpoint_height| {
+                            to_checkpoint_positions
+                                .range::<BlockHeight, _>(..=*from_checkpoint_height)
+                                .last()
+                                .map_or_else(
+                                    || {
+                                        Some((
+                                            *from_checkpoint_height,
+                                            state_final_tree.value().map_or_else(
+                                                || Checkpoint::tree_empty(),
+                                                |t| Checkpoint::at_position(t.position()),
+                                            ),
+                                        ))
+                                    },
+                                    |(to_prev_height, position)| {
+                                        if *to_prev_height < *from_checkpoint_height {
+                                            Some((
+                                                *from_checkpoint_height,
+                                                Checkpoint::at_position(*position),
+                                            ))
+                                        } else {
+                                            // The checkpoint already exists, so we don't need to
+                                            // do anything.
+                                            None
+                                        }
+                                    },
+                                )
+                                .into_iter()
                         })
-                        .map(|res| (res.subtree, res.checkpoints))
-                        .collect::<Vec<_>>();
+                        .collect::<Vec<_>>()
+                }
 
-                    // Update the Sapling note commitment tree with all newly read note commitments
-                    let mut sapling_subtrees = sapling_subtrees.into_iter();
-                    wdb.with_sapling_tree_mut::<_, _, Self::Error>(move |sapling_tree| {
-                        for (tree, checkpoints) in &mut sapling_subtrees {
+                #[cfg(feature = "orchard")]
+                let missing_sapling_checkpoints = copy_checkpoints(
+                    &orchard_checkpoint_positions,
+                    &sapling_checkpoint_positions,
+                    from_state.final_sapling_tree(),
+                );
+                #[cfg(feature = "orchard")]
+                let missing_orchard_checkpoints = copy_checkpoints(
+                    &sapling_checkpoint_positions,
+                    &orchard_checkpoint_positions,
+                    from_state.final_orchard_tree(),
+                );
+
+                // Update the Sapling note commitment tree with all newly read note commitments
+                {
+                    let mut sapling_subtrees_iter = sapling_subtrees.into_iter();
+                    wdb.with_sapling_tree_mut::<_, _, Self::Error>(|sapling_tree| {
+                        sapling_tree.insert_frontier(
+                            from_state.final_sapling_tree().clone(),
+                            Retention::Checkpoint {
+                                id: from_state.block_height(),
+                                is_marked: false,
+                            },
+                        )?;
+
+                        for (tree, checkpoints) in &mut sapling_subtrees_iter {
                             sapling_tree.insert_tree(tree, checkpoints)?;
+                        }
+
+                        // Ensure we have a Sapling checkpoint for each checkpointed Orchard block height
+                        #[cfg(feature = "orchard")]
+                        for (height, checkpoint) in dbg!(&missing_sapling_checkpoints) {
+                            sapling_tree
+                                .store_mut()
+                                .add_checkpoint(*height, checkpoint.clone())
+                                .map_err(ShardTreeError::Storage)?;
                         }
 
                         Ok(())
                     })?;
                 }
 
-                // Create subtrees from the note commitments in parallel.
+                // Update the Orchard note commitment tree with all newly read note commitments
                 #[cfg(feature = "orchard")]
                 {
-                    let orchard_subtrees = orchard_commitments
-                        .par_chunks_mut(CHUNK_SIZE)
-                        .enumerate()
-                        .filter_map(|(i, chunk)| {
-                            let start =
-                                start_positions.orchard_start_position + (i * CHUNK_SIZE) as u64;
-                            let end = start + chunk.len() as u64;
-
-                            shardtree::LocatedTree::from_iter(
-                                start..end,
-                                ORCHARD_SHARD_HEIGHT.into(),
-                                chunk.iter_mut().map(|n| n.take().expect("always Some")),
-                            )
-                        })
-                        .map(|res| (res.subtree, res.checkpoints))
-                        .collect::<Vec<_>>();
-
-                    // Update the Orchard note commitment tree with all newly read note commitments
                     let mut orchard_subtrees = orchard_subtrees.into_iter();
-                    wdb.with_orchard_tree_mut::<_, _, Self::Error>(move |orchard_tree| {
+                    wdb.with_orchard_tree_mut::<_, _, Self::Error>(|orchard_tree| {
+                        orchard_tree.insert_frontier(
+                            from_state.final_orchard_tree().clone(),
+                            Retention::Checkpoint {
+                                id: from_state.block_height(),
+                                is_marked: false,
+                            },
+                        )?;
+
                         for (tree, checkpoints) in &mut orchard_subtrees {
                             orchard_tree.insert_tree(tree, checkpoints)?;
+                        }
+
+                        for (height, checkpoint) in dbg!(&missing_orchard_checkpoints) {
+                            orchard_tree
+                                .store_mut()
+                                .add_checkpoint(*height, checkpoint.clone())
+                                .map_err(ShardTreeError::Storage)?;
                         }
 
                         Ok(())

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -1,10 +1,11 @@
-use std::convert::Infallible;
 use std::fmt;
 use std::num::NonZeroU32;
+use std::{collections::BTreeMap, convert::Infallible};
 
 #[cfg(feature = "unstable")]
 use std::fs::File;
 
+use group::ff::Field;
 use nonempty::NonEmpty;
 use prost::Message;
 use rand_chacha::ChaChaRng;
@@ -45,6 +46,7 @@ use zcash_client_backend::{
     zip321,
 };
 use zcash_client_backend::{
+    data_api::chain::ChainState,
     fees::{standard, DustOutputPolicy},
     ShieldedProtocol,
 };
@@ -76,8 +78,9 @@ use super::BlockDb;
 
 #[cfg(feature = "orchard")]
 use {
-    group::ff::{Field, PrimeField},
+    group::ff::PrimeField,
     orchard::note_encryption::{OrchardDomain, OrchardNoteEncryption},
+    orchard::tree::MerkleHashOrchard,
     pasta_curves::pallas,
     zcash_client_backend::proto::compact_formats::CompactOrchardAction,
 };
@@ -177,7 +180,8 @@ impl<Cache> TestBuilder<Cache> {
 
         TestState {
             cache: self.cache,
-            latest_cached_block: None,
+            cached_blocks: BTreeMap::new(),
+            latest_block_height: None,
             _data_file: data_file,
             db_data,
             test_account,
@@ -186,9 +190,10 @@ impl<Cache> TestBuilder<Cache> {
     }
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct CachedBlock {
-    height: BlockHeight,
     hash: BlockHash,
+    chain_state: ChainState,
     sapling_end_size: u32,
     orchard_end_size: u32,
 }
@@ -196,44 +201,87 @@ pub(crate) struct CachedBlock {
 impl CachedBlock {
     fn none(sapling_activation_height: BlockHeight) -> Self {
         Self {
-            height: sapling_activation_height,
             hash: BlockHash([0; 32]),
+            chain_state: ChainState::empty(sapling_activation_height),
             sapling_end_size: 0,
             orchard_end_size: 0,
         }
     }
 
     fn at(
-        height: BlockHeight,
         hash: BlockHash,
-        sapling_tree_size: u32,
-        orchard_tree_size: u32,
+        chain_state: ChainState,
+        sapling_end_size: u32,
+        orchard_end_size: u32,
     ) -> Self {
+        assert_eq!(
+            chain_state.final_sapling_tree().tree_size() as u32,
+            sapling_end_size
+        );
+        #[cfg(feature = "orchard")]
+        assert_eq!(
+            chain_state.final_orchard_tree().tree_size() as u32,
+            orchard_end_size
+        );
+
         Self {
-            height,
             hash,
-            sapling_end_size: sapling_tree_size,
-            orchard_end_size: orchard_tree_size,
+            chain_state,
+            sapling_end_size,
+            orchard_end_size,
         }
     }
 
-    fn roll_forward(self, cb: &CompactBlock) -> Self {
-        assert_eq!(self.height + 1, cb.height());
+    fn roll_forward(&self, cb: &CompactBlock) -> Self {
+        assert_eq!(self.chain_state.block_height() + 1, cb.height());
+
+        let sapling_final_tree = cb.vtx.iter().flat_map(|tx| tx.outputs.iter()).fold(
+            self.chain_state.final_sapling_tree().clone(),
+            |mut acc, c_out| {
+                acc.append(sapling::Node::from_cmu(&c_out.cmu().unwrap()));
+                acc
+            },
+        );
+        let sapling_end_size = sapling_final_tree.tree_size() as u32;
+
+        #[cfg(feature = "orchard")]
+        let orchard_final_tree = cb.vtx.iter().flat_map(|tx| tx.actions.iter()).fold(
+            self.chain_state.final_orchard_tree().clone(),
+            |mut acc, c_act| {
+                acc.append(MerkleHashOrchard::from_cmx(&c_act.cmx().unwrap()));
+                acc
+            },
+        );
+        #[cfg(feature = "orchard")]
+        let orchard_end_size = orchard_final_tree.tree_size() as u32;
+        #[cfg(not(feature = "orchard"))]
+        let orchard_end_size = cb.vtx.iter().fold(self.orchard_end_size, |sz, tx| {
+            sz + (tx.actions.len() as u32)
+        });
+
         Self {
-            height: cb.height(),
             hash: cb.hash(),
-            sapling_end_size: self.sapling_end_size
-                + cb.vtx.iter().map(|tx| tx.outputs.len() as u32).sum::<u32>(),
-            orchard_end_size: self.orchard_end_size
-                + cb.vtx.iter().map(|tx| tx.actions.len() as u32).sum::<u32>(),
+            chain_state: ChainState::new(
+                cb.height(),
+                sapling_final_tree,
+                #[cfg(feature = "orchard")]
+                orchard_final_tree,
+            ),
+            sapling_end_size,
+            orchard_end_size,
         }
+    }
+
+    fn height(&self) -> BlockHeight {
+        self.chain_state.block_height()
     }
 }
 
 /// The state for a `zcash_client_sqlite` test.
 pub(crate) struct TestState<Cache> {
     cache: Cache,
-    latest_cached_block: Option<CachedBlock>,
+    cached_blocks: BTreeMap<BlockHeight, CachedBlock>,
+    latest_block_height: Option<BlockHeight>,
     _data_file: NamedTempFile,
     db_data: WalletDb<Connection, LocalNetwork>,
     test_account: Option<(
@@ -256,7 +304,25 @@ where
     }
 
     pub(crate) fn latest_cached_block(&self) -> Option<&CachedBlock> {
-        self.latest_cached_block.as_ref()
+        self.latest_block_height
+            .as_ref()
+            .and_then(|h| self.prior_cached_block(*h + 1))
+    }
+
+    fn prior_cached_block(&self, height: BlockHeight) -> Option<&CachedBlock> {
+        self.cached_blocks.range(..height).last().map(|(_, b)| b)
+    }
+
+    fn cache_block(
+        &mut self,
+        prior_cached_block: &CachedBlock,
+        compact_block: CompactBlock,
+    ) -> Cache::InsertResult {
+        self.cached_blocks.insert(
+            compact_block.height(),
+            prior_cached_block.roll_forward(&compact_block),
+        );
+        self.cache.insert(&compact_block)
     }
 
     /// Creates a fake block at the expected next height containing a single output of the
@@ -267,22 +333,19 @@ where
         req: AddressType,
         value: NonNegativeAmount,
     ) -> (BlockHeight, Cache::InsertResult, Fvk::Nullifier) {
-        let cached_block = self
-            .latest_cached_block
-            .take()
-            .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
-        let height = cached_block.height + 1;
+        let pre_activation_block = CachedBlock::none(self.sapling_activation_height() - 1);
+        let prior_cached_block = self.latest_cached_block().unwrap_or(&pre_activation_block);
+        let height = prior_cached_block.height() + 1;
 
         let (res, nf) = self.generate_block_at(
             height,
-            cached_block.hash,
+            prior_cached_block.hash,
             fvk,
             req,
             value,
-            cached_block.sapling_end_size,
-            cached_block.orchard_end_size,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
         );
-        assert!(self.latest_cached_block.is_some());
 
         (height, res, nf)
     }
@@ -303,6 +366,59 @@ where
         initial_sapling_tree_size: u32,
         initial_orchard_tree_size: u32,
     ) -> (Cache::InsertResult, Fvk::Nullifier) {
+        let mut prior_cached_block = self
+            .prior_cached_block(height)
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
+        assert!(prior_cached_block.chain_state.block_height() < height);
+        assert!(prior_cached_block.sapling_end_size <= initial_sapling_tree_size);
+        assert!(prior_cached_block.orchard_end_size <= initial_orchard_tree_size);
+
+        // If the block height has increased or the Sapling and/or Orchard tree sizes have changed,
+        // we need to generate a new prior cached block that the block to be generated can
+        // successfully chain from, with the provided tree sizes.
+        if prior_cached_block.chain_state.block_height() == height - 1 {
+            assert_eq!(prev_hash, prior_cached_block.hash);
+        } else {
+            dbg!("cache gap", prior_cached_block.chain_state.block_height()..height);
+
+            let final_sapling_tree =
+                dbg!(prior_cached_block.sapling_end_size..initial_sapling_tree_size).fold(
+                    prior_cached_block.chain_state.final_sapling_tree().clone(),
+                    |mut acc, _| {
+                        acc.append(sapling::Node::from_scalar(bls12_381::Scalar::random(
+                            &mut self.rng,
+                        )));
+                        acc
+                    },
+                );
+
+            #[cfg(feature = "orchard")]
+            let final_orchard_tree =
+                dbg!(prior_cached_block.orchard_end_size..initial_orchard_tree_size).fold(
+                    prior_cached_block.chain_state.final_orchard_tree().clone(),
+                    |mut acc, _| {
+                        acc.append(MerkleHashOrchard::random(&mut self.rng));
+                        acc
+                    },
+                );
+
+            prior_cached_block = CachedBlock::at(
+                prev_hash,
+                ChainState::new(
+                    height - 1,
+                    final_sapling_tree,
+                    #[cfg(feature = "orchard")]
+                    final_orchard_tree,
+                ),
+                initial_sapling_tree_size,
+                initial_orchard_tree_size,
+            );
+
+            self.cached_blocks
+                .insert(height - 1, prior_cached_block.clone());
+        }
+
         let (cb, nf) = fake_compact_block(
             &self.network(),
             height,
@@ -314,17 +430,10 @@ where
             initial_orchard_tree_size,
             &mut self.rng,
         );
-        let res = self.cache.insert(&cb);
+        assert_eq!(cb.height(), height);
 
-        self.latest_cached_block = Some(
-            CachedBlock::at(
-                height - 1,
-                cb.hash(),
-                initial_sapling_tree_size,
-                initial_orchard_tree_size,
-            )
-            .roll_forward(&cb),
-        );
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
 
         (res, nf)
     }
@@ -338,27 +447,28 @@ where
         to: impl Into<Address>,
         value: NonNegativeAmount,
     ) -> (BlockHeight, Cache::InsertResult) {
-        let cached_block = self
-            .latest_cached_block
-            .take()
+        let prior_cached_block = self
+            .latest_cached_block()
+            .cloned()
             .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
-        let height = cached_block.height + 1;
+        let height = prior_cached_block.height() + 1;
 
         let cb = fake_compact_block_spending(
             &self.network(),
             height,
-            cached_block.hash,
+            prior_cached_block.hash,
             note,
             fvk,
             to.into(),
             value,
-            cached_block.sapling_end_size,
-            cached_block.orchard_end_size,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
             &mut self.rng,
         );
-        let res = self.cache.insert(&cb);
+        assert_eq!(cb.height(), height);
 
-        self.latest_cached_block = Some(cached_block.roll_forward(&cb));
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
 
         (height, res)
     }
@@ -393,24 +503,25 @@ where
         tx_index: usize,
         tx: &Transaction,
     ) -> (BlockHeight, Cache::InsertResult) {
-        let cached_block = self
-            .latest_cached_block
-            .take()
+        let prior_cached_block = self
+            .latest_cached_block()
+            .cloned()
             .unwrap_or_else(|| CachedBlock::none(self.sapling_activation_height() - 1));
-        let height = cached_block.height + 1;
+        let height = prior_cached_block.height() + 1;
 
         let cb = fake_compact_block_from_tx(
             height,
-            cached_block.hash,
+            prior_cached_block.hash,
             tx_index,
             tx,
-            cached_block.sapling_end_size,
-            cached_block.orchard_end_size,
+            prior_cached_block.sapling_end_size,
+            prior_cached_block.orchard_end_size,
             &mut self.rng,
         );
-        let res = self.cache.insert(&cb);
+        assert_eq!(cb.height(), height);
 
-        self.latest_cached_block = Some(cached_block.roll_forward(&cb));
+        let res = self.cache_block(&prior_cached_block, cb);
+        self.latest_block_height = Some(height);
 
         (height, res)
     }
@@ -438,13 +549,19 @@ where
             <Cache::BlockSource as BlockSource>::Error,
         >,
     > {
-        scan_cached_blocks(
+        let prior_cached_block = self
+            .prior_cached_block(from_height)
+            .cloned()
+            .unwrap_or_else(|| CachedBlock::none(from_height - 1));
+
+        let result = scan_cached_blocks(
             &self.network(),
             self.cache.block_source(),
             &mut self.db_data,
-            from_height,
+            &prior_cached_block.chain_state,
             limit,
-        )
+        );
+        result
     }
 
     /// Resets the wallet using a new wallet database but with the same cache of blocks,
@@ -455,7 +572,7 @@ where
     /// Before using any `generate_*` method on the reset state, call `reset_latest_cached_block()`.
     pub(crate) fn reset(&mut self) -> NamedTempFile {
         let network = self.network();
-        self.latest_cached_block = None;
+        self.latest_block_height = None;
         let tf = std::mem::replace(&mut self._data_file, NamedTempFile::new().unwrap());
         self.db_data = WalletDb::for_path(self._data_file.path(), network).unwrap();
         self.test_account = None;
@@ -463,23 +580,23 @@ where
         tf
     }
 
-    /// Reset the latest cached block to the most recent one in the cache database.
-    #[allow(dead_code)]
-    pub(crate) fn reset_latest_cached_block(&mut self) {
-        self.cache
-            .block_source()
-            .with_blocks::<_, Infallible>(None, None, |block: CompactBlock| {
-                let chain_metadata = block.chain_metadata.unwrap();
-                self.latest_cached_block = Some(CachedBlock::at(
-                    BlockHeight::from_u32(block.height.try_into().unwrap()),
-                    BlockHash::from_slice(block.hash.as_slice()),
-                    chain_metadata.sapling_commitment_tree_size,
-                    chain_metadata.orchard_commitment_tree_size,
-                ));
-                Ok(())
-            })
-            .unwrap();
-    }
+    //    /// Reset the latest cached block to the most recent one in the cache database.
+    //    #[allow(dead_code)]
+    //    pub(crate) fn reset_latest_cached_block(&mut self) {
+    //        self.cache
+    //            .block_source()
+    //            .with_blocks::<_, Infallible>(None, None, |block: CompactBlock| {
+    //                let chain_metadata = block.chain_metadata.unwrap();
+    //                self.latest_cached_block = Some(CachedBlock::at(
+    //                    BlockHash::from_slice(block.hash.as_slice()),
+    //                    BlockHeight::from_u32(block.height.try_into().unwrap()),
+    //                    chain_metadata.sapling_commitment_tree_size,
+    //                    chain_metadata.orchard_commitment_tree_size,
+    //                ));
+    //                Ok(())
+    //            })
+    //            .unwrap();
+    //    }
 }
 
 impl<Cache> TestState<Cache> {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -1453,7 +1453,7 @@ pub(crate) fn cross_pool_exchange<P0: ShieldedPoolTester, P1: ShieldedPoolTester
 
     let _min_target_height = proposal0.min_target_height();
     assert_eq!(proposal0.steps().len(), 1);
-    let step0 = &proposal0.steps().head;
+    let step0 = dbg!(&proposal0.steps().head);
 
     // We expect 4 logical actions, two per pool (due to padding).
     let expected_fee = NonNegativeAmount::const_from_u64(20000);

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2945,23 +2945,6 @@ mod tests {
         // Scan a block above the wallet's birthday height.
         let not_our_key = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
         let not_our_value = NonNegativeAmount::const_from_u64(10000);
-        let end_height = st.sapling_activation_height() + 2;
-        let _ = st.generate_block_at(
-            end_height,
-            BlockHash([37; 32]),
-            &not_our_key,
-            AddressType::DefaultExternal,
-            not_our_value,
-            17,
-            17,
-        );
-        st.scan_cached_blocks(end_height, 1);
-
-        // The wallet should still have no fully-scanned block, as no scanned block range
-        // overlaps the wallet's birthday.
-        assert_eq!(block_fully_scanned(&st), None);
-
-        // Scan the block at the wallet's birthday height.
         let start_height = st.sapling_activation_height();
         let _ = st.generate_block_at(
             start_height,
@@ -2972,15 +2955,26 @@ mod tests {
             0,
             0,
         );
+        let (mid_height, _, _) =
+            st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+        let (end_height, _, _) =
+            st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
+
+        // Scan the last block first
+        st.scan_cached_blocks(end_height, 1);
+
+        // The wallet should still have no fully-scanned block, as no scanned block range
+        // overlaps the wallet's birthday.
+        assert_eq!(block_fully_scanned(&st), None);
+
+        // Scan the block at the wallet's birthday height.
         st.scan_cached_blocks(start_height, 1);
 
         // The fully-scanned height should now be that of the scanned block.
         assert_eq!(block_fully_scanned(&st), Some(start_height));
 
         // Scan the block in between the two previous blocks.
-        let (h, _, _) =
-            st.generate_next_block(&not_our_key, AddressType::DefaultExternal, not_our_value);
-        st.scan_cached_blocks(h, 1);
+        st.scan_cached_blocks(mid_height, 1);
 
         // The fully-scanned height should now be the latest block, as the two disjoint
         // ranges have been connected.


### PR DESCRIPTION
…anned range.

In order to support constructing the anchor for multiple pools with a common anchor height, we must be able to checkpoint each note commitment tree (and consequently compute the root) at that height. Since we may not have the information in the tree needed to do so, we require that it be provided.

As a bonus, this change makes it possible to improve the UX around spendability, because we will no longer require subtree ranges below received notes to be fully scanned; the inserted frontier provides sufficient information to make them spendable.