### PR TITLE
Simplify change strategies, and deprecate or remove fee rules that no longer produce minable transactions

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::value::DivRem`
+- `zcash_protocol::value::Zatoshis::div_with_remainder`
+
 ## [0.4.0] - 2024-10-02
 ### Added
 - `impl Sub<BlockHeight> for BlockHeight` unlike the implementation that was

--- a/components/zcash_protocol/src/value.rs
+++ b/components/zcash_protocol/src/value.rs
@@ -1,6 +1,7 @@
 use std::convert::{Infallible, TryFrom};
 use std::error;
 use std::iter::Sum;
+use std::num::NonZeroU64;
 use std::ops::{Add, Mul, Neg, Sub};
 
 use memuse::DynamicUsage;
@@ -229,6 +230,24 @@ impl Mul<usize> for ZatBalance {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Zatoshis(u64);
 
+/// A struct that provides both the quotient and remainder of a division operation.
+pub struct QuotRem<A> {
+    quotient: A,
+    remainder: A,
+}
+
+impl<A> QuotRem<A> {
+    /// Returns the quotient portion of the value.
+    pub fn quotient(&self) -> &A {
+        &self.quotient
+    }
+
+    /// Returns the remainder portion of the value.
+    pub fn remainder(&self) -> &A {
+        &self.remainder
+    }
+}
+
 impl Zatoshis {
     /// Returns the identity `Zatoshis`
     pub const ZERO: Self = Zatoshis(0);
@@ -297,6 +316,15 @@ impl Zatoshis {
     /// Returns whether or not this `Zatoshis` is positive.
     pub fn is_positive(&self) -> bool {
         self > &Zatoshis::ZERO
+    }
+
+    /// Divides this `Zatoshis` value by the given divisor and returns the quotient and remainder.
+    pub fn div_with_remainder(&self, divisor: NonZeroU64) -> QuotRem<Zatoshis> {
+        let divisor = u64::from(divisor);
+        QuotRem {
+            quotient: Zatoshis(self.0 / divisor),
+            remainder: Zatoshis(self.0 % divisor),
+        }
     }
 }
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -59,6 +59,10 @@ and this library adheres to Rust's notion of
     - `fixed::SingleOutputChangeStrategy::new`
     - `standard::SingleOutputChangeStrategy::new`
     - `zip317::SingleOutputChangeStrategy::new`
+- `zcash_client_backend::proto`:
+  - The `FeeRuleNotSpecified` variant of `FeeProposalDecodingError` has been
+    renamed to `FeeRuleNotSupported`. It is now used to report attempted use
+    of unsupported fee rules, as well as of an unspecified fee rule.
 
 ### Changed
 - Migrated to `arti-client 0.22`.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -24,12 +24,12 @@ and this library adheres to Rust's notion of
     `ChangeErrT` and `NoteRefT`.
   - The following methods each now take an additional `change_strategy`
     argument, along with an associated `ChangeT` type parameter:
-    - `zcash_client_backend::data_api::wallet::spend`
-    - `zcash_client_backend::data_api::wallet::propose_transfer`
-    - `zcash_client_backend::data_api::wallet::propose_shielding`. This method
-      also now takes an additional `to_account` argument.
-    - `zcash_client_backend::data_api::wallet::shield_transparent_funds`. This
-      method also now takes an additional `to_account` argument.
+    - `wallet::spend`
+    - `wallet::propose_transfer`
+    - `wallet::propose_shielding`. This method also now takes an additional
+      `to_account` argument.
+    - `wallet::shield_transparent_funds`. This method also now takes an
+      additional `to_account` argument.
   - `wallet::input_selection::InputSelectionError` now has an additional `Change`
     variant. This necessitates the addition of two type parameters.
   - `wallet::input_selection::InputSelector::propose_transaction` takes an
@@ -49,20 +49,16 @@ and this library adheres to Rust's notion of
     has been removed, along with the additional type parameters it necessitated.
   - The arguments to `wallet::input_selection::GreedyInputSelector::new` have
     changed.
-- `zcash_client_backend::fees::ChangeStrategy` has changed. It has two new
-  associated types, `MetaSource` and `WalletMeta`, and its `FeeRule` associated
-  type now has an additional `Clone` bound. In addition, it defines a new
-  `fetch_wallet_meta` method, and the arguments to `compute_balance` have
-  changed.
-- `zcash_client_backend::fees::fixed::SingleOutputChangeStrategy::new`
-  now takes an additional `DustOutputPolicy` argument. It also now carries
-  an additional type parameter.
-- `zcash_client_backend::fees::standard::SingleOutputChangeStrategy::new`
-  now takes an additional `DustOutputPolicy` argument. It also now carries
-  an additional type parameter.
-- `zcash_client_backend::fees::zip317::SingleOutputChangeStrategy::new`
-  now takes an additional `DustOutputPolicy` argument. It also now carries
-  an additional type parameter.
+- `zcash_client_backend::fees`:
+  - `ChangeStrategy` has changed. It has two new associated types, `MetaSource`
+    and `WalletMeta`, and its `FeeRule` associated type now has an additional
+    `Clone` bound. In addition, it defines a new `fetch_wallet_meta` method, and
+    the arguments to `compute_balance` have changed.
+  - The following methods now take an additional `DustOutputPolicy` argument,
+    and carry an additional type parameter:
+    - `fixed::SingleOutputChangeStrategy::new`
+    - `standard::SingleOutputChangeStrategy::new`
+    - `zip317::SingleOutputChangeStrategy::new`
 
 ### Changed
 - Migrated to `arti-client 0.22`.
@@ -71,6 +67,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api`:
   - `WalletSummary::scan_progress` and `WalletSummary::recovery_progress` have
     been removed. Use `WalletSummary::progress` instead.
+  - `testing::input_selector` use explicit `InputSelector` constructors
+    directly instead.
 - `zcash_client_backend::fees`:
   - `impl From<BalanceError> for ChangeError<...>`
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,8 +13,10 @@ and this library adheres to Rust's notion of
   - `WalletSummary::progress`
   - `WalletMeta`
   - `impl Default for wallet::input_selection::GreedyInputSelector`
-- `zcash_client_backend::fees::SplitPolicy`
-- `zcash_client_backend::fees::zip317::MultiOutputChangeStrategy`
+- `zcash_client_backend::fees::{SplitPolicy, CommonChangeStrategy}`. These
+  allow specifying a policy for splitting change into more than one output,
+  which can help to make enough notes available to perform multiple spends
+  without waiting for change.
 
 ### Changed
 - `zcash_client_backend::data_api`:
@@ -54,11 +56,6 @@ and this library adheres to Rust's notion of
     and `WalletMeta`, and its `FeeRule` associated type now has an additional
     `Clone` bound. In addition, it defines a new `fetch_wallet_meta` method, and
     the arguments to `compute_balance` have changed.
-  - The following methods now take an additional `DustOutputPolicy` argument,
-    and carry an additional type parameter:
-    - `fixed::SingleOutputChangeStrategy::new`
-    - `standard::SingleOutputChangeStrategy::new`
-    - `zip317::SingleOutputChangeStrategy::new`
 - `zcash_client_backend::proto`:
   - The `FeeRuleNotSpecified` variant of `FeeProposalDecodingError` has been
     renamed to `FeeRuleNotSupported`. It is now used to report attempted use
@@ -67,12 +64,19 @@ and this library adheres to Rust's notion of
 ### Changed
 - Migrated to `arti-client 0.22`.
 
+### Deprecated
+- `zcash_client_backend::fees::{fixed,standard,zip317}::SingleOutputChangeStrategy::new`
+  have been deprecated: instead use `CommonChangeStrategy::simple`.
+  (For most uses, the type parameter of the fee rule will be inferred.)
+
 ### Removed
 - `zcash_client_backend::data_api`:
   - `WalletSummary::scan_progress` and `WalletSummary::recovery_progress` have
     been removed. Use `WalletSummary::progress` instead.
-  - `testing::input_selector` use explicit `InputSelector` constructors
+  - `testing::input_selector`. Use explicit `InputSelector` constructors
     directly instead.
+  - `testing::single_output_change_strategy`. Use `fees::CommonChangeStrategy::simple`
+    instead.
 - `zcash_client_backend::fees`:
   - `impl From<BalanceError> for ChangeError<...>`
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -13,6 +13,8 @@ and this library adheres to Rust's notion of
   - `WalletSummary::progress`
   - `WalletMeta`
   - `impl Default for wallet::input_selection::GreedyInputSelector`
+- `zcash_client_backend::fees::SplitPolicy`
+- `zcash_client_backend::fees::zip317::MultiOutputChangeStrategy`
 
 ### Changed
 - `zcash_client_backend::data_api`:

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,10 +12,55 @@ and this library adheres to Rust's notion of
   - `Progress`
   - `WalletSummary::progress`
   - `WalletMeta`
+  - `impl Default for wallet::input_selection::GreedyInputSelector`
 
 ### Changed
 - `zcash_client_backend::data_api`:
   - `InputSource` has an added method `get_wallet_metadata`
+  - `error::Error` has additional variant `Error::Change`. This necessitates
+    the addition of two type parameters to the `Error` type,
+    `ChangeErrT` and `NoteRefT`.
+  - The following methods each now take an additional `change_strategy`
+    argument, along with an associated `ChangeT` type parameter:
+    - `zcash_client_backend::data_api::wallet::spend`
+    - `zcash_client_backend::data_api::wallet::propose_transfer`
+    - `zcash_client_backend::data_api::wallet::propose_shielding`. This method
+      also now takes an additional `to_account` argument.
+    - `zcash_client_backend::data_api::wallet::shield_transparent_funds`. This
+      method also now takes an additional `to_account` argument.
+  - `wallet::input_selection::InputSelectionError` now has an additional `Change`
+    variant. This necessitates the addition of two type parameters.
+  - `wallet::input_selection::InputSelector::propose_transaction` takes an
+    additional `change_strategy` argument, along with an associated `ChangeT`
+    type parameter.
+  - The `wallet::input_selection::InputSelector::FeeRule` associated type has
+    been removed. The fee rule is now part of the change strategy passed to
+    `propose_transaction`.
+  - `wallet::input_selection::ShieldingSelector::propose_shielding` takes an
+    additional `change_strategy` argument, along with an associated `ChangeT`
+    type parameter. In addition, it also takes a new `to_account` argument
+    that identifies the destination account for the shielded notes.
+  - The `wallet::input_selection::ShieldingSelector::FeeRule` associated type
+    has been removed. The fee rule is now part of the change strategy passed to
+    `propose_shielding`.
+  - The `Change` variant of `wallet::input_selection::GreedyInputSelectorError`
+    has been removed, along with the additional type parameters it necessitated.
+  - The arguments to `wallet::input_selection::GreedyInputSelector::new` have
+    changed.
+- `zcash_client_backend::fees::ChangeStrategy` has changed. It has two new
+  associated types, `MetaSource` and `WalletMeta`, and its `FeeRule` associated
+  type now has an additional `Clone` bound. In addition, it defines a new
+  `fetch_wallet_meta` method, and the arguments to `compute_balance` have
+  changed.
+- `zcash_client_backend::fees::fixed::SingleOutputChangeStrategy::new`
+  now takes an additional `DustOutputPolicy` argument. It also now carries
+  an additional type parameter.
+- `zcash_client_backend::fees::standard::SingleOutputChangeStrategy::new`
+  now takes an additional `DustOutputPolicy` argument. It also now carries
+  an additional type parameter.
+- `zcash_client_backend::fees::zip317::SingleOutputChangeStrategy::new`
+  now takes an additional `DustOutputPolicy` argument. It also now carries
+  an additional type parameter.
 
 ### Changed
 - Migrated to `arti-client 0.22`.
@@ -24,6 +69,8 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api`:
   - `WalletSummary::scan_progress` and `WalletSummary::recovery_progress` have
     been removed. Use `WalletSummary::progress` instead.
+- `zcash_client_backend::fees`:
+  - `impl From<BalanceError> for ChangeError<...>`
 
 ## [0.14.0] - 2024-10-04
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,11 @@ and this library adheres to Rust's notion of
 - `zcash_client_backend::data_api`:
   - `Progress`
   - `WalletSummary::progress`
+  - `WalletMeta`
+
+### Changed
+- `zcash_client_backend::data_api`:
+  - `InputSource` has an added method `get_wallet_metadata`
 
 ### Changed
 - Migrated to `arti-client 0.22`.
@@ -27,7 +32,7 @@ and this library adheres to Rust's notion of
   - `GAP_LIMIT`
   - `WalletSummary::recovery_progress`
   - `SpendableNotes::{take_sapling, take_orchard}`
-  - Tests and testing infrastructure have been migrated from the 
+  - Tests and testing infrastructure have been migrated from the
     `zcash_client_sqlite` internal tests to the `testing` module, and have been
     generalized so that they may be used for testing arbitrary implementations
     of the `zcash_client_backend::data_api` interfaces. The following have been

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -794,7 +794,7 @@ impl<NoteRef> SpendableNotes<NoteRef> {
     }
 }
 
-/// Metadata about the structure of the wallet for a particular account. 
+/// Metadata about the structure of the wallet for a particular account.
 ///
 /// At present this just contains counts of unspent outputs in each pool, but it may be extended in
 /// the future to contain note values or other more detailed information about wallet structure.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -907,7 +907,7 @@ pub trait InputSource {
         account: Self::AccountId,
         min_value: NonNegativeAmount,
         exclude: &[Self::NoteRef],
-    ) -> Result<WalletMeta, Self::Error>;
+    ) -> Result<Option<WalletMeta>, Self::Error>;
 
     /// Fetches the transparent output corresponding to the provided `outpoint`.
     ///

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -848,12 +848,7 @@ impl WalletMeta {
     /// Returns the total number of unspent shielded notes belonging to the account for which this
     /// was generated.
     pub fn total_note_count(&self) -> usize {
-        #[cfg(feature = "orchard")]
-        let orchard_note_count = self.orchard_note_count;
-        #[cfg(not(feature = "orchard"))]
-        let orchard_note_count = 0;
-
-        self.sapling_note_count + orchard_note_count
+        self.sapling_note_count + self.note_count(ShieldedProtocol::Orchard)
     }
 }
 
@@ -903,8 +898,10 @@ pub trait InputSource {
 
     /// Returns metadata describing the structure of the wallet for the specified account.
     ///
-    /// The returned metadata value must exclude spent notes and unspent notes having value less
-    /// than the specified minimum value or identified in the given exclude list.
+    /// The returned metadata value must exclude:
+    /// - spent notes;
+    /// - unspent notes having value less than the specified minimum value;
+    /// - unspent notes identified in the given `exclude` list.
     fn get_wallet_metadata(
         &self,
         account: Self::AccountId,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -1221,12 +1221,6 @@ impl<Cache, DbT: WalletRead + Reset> TestState<Cache, DbT, LocalNetwork> {
     //    }
 }
 
-/// Helper method for constructing a [`GreedyInputSelector`] with a
-/// [`standard::SingleOutputChangeStrategy`].
-pub fn input_selector<DbT: InputSource>() -> GreedyInputSelector<DbT> {
-    GreedyInputSelector::<DbT>::new()
-}
-
 pub fn single_output_change_strategy<DbT: InputSource>(
     fee_rule: StandardFeeRule,
     change_memo: Option<&str>,

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -56,7 +56,6 @@ use crate::{
     ShieldedProtocol,
 };
 
-use super::WalletTest;
 #[allow(deprecated)]
 use super::{
     chain::{scan_cached_blocks, BlockSource, ChainState, CommitmentTreeRoot, ScanSummary},
@@ -69,7 +68,8 @@ use super::{
     Account, AccountBalance, AccountBirthday, AccountPurpose, AccountSource, BlockMetadata,
     DecryptedTransaction, InputSource, NullifierQuery, ScannedBlock, SeedRelevance,
     SentTransaction, SpendableNotes, TransactionDataRequest, TransactionStatus,
-    WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite, SAPLING_SHARD_HEIGHT,
+    WalletCommitmentTrees, WalletMeta, WalletRead, WalletSummary, WalletTest, WalletWrite,
+    SAPLING_SHARD_HEIGHT,
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -2377,6 +2377,15 @@ impl InputSource for MockWalletDb {
         _exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
         Ok(SpendableNotes::empty())
+    }
+
+    fn get_wallet_metadata(
+        &self,
+        _account: Self::AccountId,
+        _min_value: NonNegativeAmount,
+        _exclude: &[Self::NoteRef],
+    ) -> Result<WalletMeta, Self::Error> {
+        Err(())
     }
 }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -31,7 +31,7 @@ use zcash_primitives::{
     memo::Memo,
     transaction::{
         components::{amount::NonNegativeAmount, sapling::zip212_enforcement},
-        fees::{zip317::FeeError as Zip317FeeError, FeeRule, StandardFeeRule},
+        fees::{FeeRule, StandardFeeRule},
         Transaction, TxId,
     },
 };
@@ -46,7 +46,10 @@ use zip32::{fingerprint::SeedFingerprint, DiversifierIndex};
 
 use crate::{
     address::UnifiedAddress,
-    fees::{standard, DustOutputPolicy},
+    fees::{
+        standard::{self, SingleOutputChangeStrategy},
+        ChangeStrategy, DustOutputPolicy,
+    },
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
     proposal::Proposal,
     proto::compact_formats::{
@@ -62,7 +65,7 @@ use super::{
     scanning::ScanRange,
     wallet::{
         create_proposed_transactions, create_spend_to_address,
-        input_selection::{GreedyInputSelector, GreedyInputSelectorError, InputSelector},
+        input_selection::{GreedyInputSelector, InputSelector},
         propose_standard_transfer_to_address, propose_transfer, spend,
     },
     Account, AccountBalance, AccountBirthday, AccountPurpose, AccountSource, BlockMetadata,
@@ -874,12 +877,7 @@ where
         fallback_change_pool: ShieldedProtocol,
     ) -> Result<
         NonEmpty<TxId>,
-        super::error::Error<
-            ErrT,
-            <DbT as WalletCommitmentTrees>::Error,
-            GreedyInputSelectorError<Zip317FeeError, <DbT as InputSource>::NoteRef>,
-            Zip317FeeError,
-        >,
+        super::wallet::TransferErrT<DbT, GreedyInputSelector<DbT>, SingleOutputChangeStrategy<DbT>>,
     > {
         let prover = LocalTxProver::bundled();
         let network = self.network().clone();
@@ -901,24 +899,18 @@ where
 
     /// Invokes [`spend`] with the given arguments.
     #[allow(clippy::type_complexity)]
-    pub fn spend<InputsT>(
+    pub fn spend<InputsT, ChangeT>(
         &mut self,
         input_selector: &InputsT,
+        change_strategy: &ChangeT,
         usk: &UnifiedSpendingKey,
         request: zip321::TransactionRequest,
         ovk_policy: OvkPolicy,
         min_confirmations: NonZeroU32,
-    ) -> Result<
-        NonEmpty<TxId>,
-        super::error::Error<
-            ErrT,
-            <DbT as WalletCommitmentTrees>::Error,
-            InputsT::Error,
-            <InputsT::FeeRule as FeeRule>::Error,
-        >,
-    >
+    ) -> Result<NonEmpty<TxId>, super::wallet::TransferErrT<DbT, InputsT, ChangeT>>
     where
         InputsT: InputSelector<InputSource = DbT>,
+        ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
         #![allow(deprecated)]
         let prover = LocalTxProver::bundled();
@@ -929,6 +921,7 @@ where
             &prover,
             &prover,
             input_selector,
+            change_strategy,
             usk,
             request,
             ovk_policy,
@@ -938,25 +931,28 @@ where
 
     /// Invokes [`propose_transfer`] with the given arguments.
     #[allow(clippy::type_complexity)]
-    pub fn propose_transfer<InputsT>(
+    pub fn propose_transfer<InputsT, ChangeT>(
         &mut self,
         spend_from_account: <DbT as InputSource>::AccountId,
         input_selector: &InputsT,
+        change_strategy: &ChangeT,
         request: zip321::TransactionRequest,
         min_confirmations: NonZeroU32,
     ) -> Result<
-        Proposal<InputsT::FeeRule, <DbT as InputSource>::NoteRef>,
-        super::error::Error<ErrT, Infallible, InputsT::Error, <InputsT::FeeRule as FeeRule>::Error>,
+        Proposal<ChangeT::FeeRule, <DbT as InputSource>::NoteRef>,
+        super::wallet::ProposeTransferErrT<DbT, Infallible, InputsT, ChangeT>,
     >
     where
         InputsT: InputSelector<InputSource = DbT>,
+        ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
         let network = self.network().clone();
-        propose_transfer::<_, _, _, Infallible>(
+        propose_transfer::<_, _, _, _, Infallible>(
             self.wallet_mut(),
             &network,
             spend_from_account,
             input_selector,
+            change_strategy,
             request,
             min_confirmations,
         )
@@ -977,11 +973,11 @@ where
         fallback_change_pool: ShieldedProtocol,
     ) -> Result<
         Proposal<StandardFeeRule, <DbT as InputSource>::NoteRef>,
-        super::error::Error<
-            ErrT,
+        super::wallet::ProposeTransferErrT<
+            DbT,
             CommitmentTreeErrT,
-            GreedyInputSelectorError<Zip317FeeError, <DbT as InputSource>::NoteRef>,
-            Zip317FeeError,
+            GreedyInputSelector<DbT>,
+            SingleOutputChangeStrategy<DbT>,
         >,
     > {
         let network = self.network().clone();
@@ -1011,47 +1007,47 @@ where
     #[cfg(feature = "transparent-inputs")]
     #[allow(clippy::type_complexity)]
     #[allow(dead_code)]
-    pub fn propose_shielding<InputsT>(
+    pub fn propose_shielding<InputsT, ChangeT>(
         &mut self,
         input_selector: &InputsT,
+        change_strategy: &ChangeT,
         shielding_threshold: NonNegativeAmount,
         from_addrs: &[TransparentAddress],
+        to_account: <InputsT::InputSource as InputSource>::AccountId,
         min_confirmations: u32,
     ) -> Result<
-        Proposal<InputsT::FeeRule, Infallible>,
-        super::error::Error<ErrT, Infallible, InputsT::Error, <InputsT::FeeRule as FeeRule>::Error>,
+        Proposal<ChangeT::FeeRule, Infallible>,
+        super::wallet::ProposeShieldingErrT<DbT, Infallible, InputsT, ChangeT>,
     >
     where
         InputsT: ShieldingSelector<InputSource = DbT>,
+        ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
         use super::wallet::propose_shielding;
 
         let network = self.network().clone();
-        propose_shielding::<_, _, _, Infallible>(
+        propose_shielding::<_, _, _, _, Infallible>(
             self.wallet_mut(),
             &network,
             input_selector,
+            change_strategy,
             shielding_threshold,
             from_addrs,
+            to_account,
             min_confirmations,
         )
     }
 
     /// Invokes [`create_proposed_transactions`] with the given arguments.
     #[allow(clippy::type_complexity)]
-    pub fn create_proposed_transactions<InputsErrT, FeeRuleT>(
+    pub fn create_proposed_transactions<InputsErrT, FeeRuleT, ChangeErrT>(
         &mut self,
         usk: &UnifiedSpendingKey,
         ovk_policy: OvkPolicy,
         proposal: &Proposal<FeeRuleT, <DbT as InputSource>::NoteRef>,
     ) -> Result<
         NonEmpty<TxId>,
-        super::error::Error<
-            ErrT,
-            <DbT as WalletCommitmentTrees>::Error,
-            InputsErrT,
-            FeeRuleT::Error,
-        >,
+        super::wallet::CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, DbT::NoteRef>,
     >
     where
         FeeRuleT: FeeRule,
@@ -1074,24 +1070,20 @@ where
     /// [`shield_transparent_funds`]: crate::data_api::wallet::shield_transparent_funds
     #[cfg(feature = "transparent-inputs")]
     #[allow(clippy::type_complexity)]
-    pub fn shield_transparent_funds<InputsT>(
+    #[allow(clippy::too_many_arguments)]
+    pub fn shield_transparent_funds<InputsT, ChangeT>(
         &mut self,
         input_selector: &InputsT,
+        change_strategy: &ChangeT,
         shielding_threshold: NonNegativeAmount,
         usk: &UnifiedSpendingKey,
         from_addrs: &[TransparentAddress],
+        to_account: <DbT as InputSource>::AccountId,
         min_confirmations: u32,
-    ) -> Result<
-        NonEmpty<TxId>,
-        super::error::Error<
-            ErrT,
-            <DbT as WalletCommitmentTrees>::Error,
-            InputsT::Error,
-            <InputsT::FeeRule as FeeRule>::Error,
-        >,
-    >
+    ) -> Result<NonEmpty<TxId>, super::wallet::ShieldErrT<DbT, InputsT, ChangeT>>
     where
         InputsT: ShieldingSelector<InputSource = DbT>,
+        ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
         use crate::data_api::wallet::shield_transparent_funds;
 
@@ -1103,9 +1095,11 @@ where
             &prover,
             &prover,
             input_selector,
+            change_strategy,
             shielding_threshold,
             usk,
             from_addrs,
+            to_account,
             min_confirmations,
         )
     }
@@ -1229,15 +1223,22 @@ impl<Cache, DbT: WalletRead + Reset> TestState<Cache, DbT, LocalNetwork> {
 
 /// Helper method for constructing a [`GreedyInputSelector`] with a
 /// [`standard::SingleOutputChangeStrategy`].
-pub fn input_selector<DbT: InputSource>(
+pub fn input_selector<DbT: InputSource>() -> GreedyInputSelector<DbT> {
+    GreedyInputSelector::<DbT>::new()
+}
+
+pub fn single_output_change_strategy<DbT: InputSource>(
     fee_rule: StandardFeeRule,
     change_memo: Option<&str>,
     fallback_change_pool: ShieldedProtocol,
-) -> GreedyInputSelector<DbT, standard::SingleOutputChangeStrategy> {
+) -> standard::SingleOutputChangeStrategy<DbT> {
     let change_memo = change_memo.map(|m| MemoBytes::from(m.parse::<Memo>().unwrap()));
-    let change_strategy =
-        standard::SingleOutputChangeStrategy::new(fee_rule, change_memo, fallback_change_pool);
-    GreedyInputSelector::new(change_strategy, DustOutputPolicy::default())
+    standard::SingleOutputChangeStrategy::new(
+        fee_rule,
+        change_memo,
+        fallback_change_pool,
+        DustOutputPolicy::default(),
+    )
 }
 
 // Checks that a protobuf proposal serialized from the provided proposal value correctly parses to

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -1018,7 +1018,7 @@ where
     assert_matches!(
         st.propose_standard_transfer::<Infallible>(
             account_id,
-            StandardFeeRule::PreZip313,
+            StandardFeeRule::Zip317,
             NonZeroU32::new(1).unwrap(),
             &to,
             NonNegativeAmount::const_from_u64(1),

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -422,7 +422,7 @@ pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
         .unwrap();
     assert_eq!(sent_note_ids.len(), 3);
 
-    // The sent memo should be the empty memo for the sent output, and the
+    // The sent memo should be the empty memo for the sent output, and each
     // change output's memo should be as specified.
     let mut change_memo_count = 0;
     let mut found_sent_empty_memo = false;

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -17,7 +17,11 @@ use zcash_primitives::{
     legacy::TransparentAddress,
     transaction::{
         components::amount::NonNegativeAmount,
-        fees::{fixed::FeeRule as FixedFeeRule, zip317::FeeRule as Zip317FeeRule, StandardFeeRule},
+        fees::{
+            fixed::FeeRule as FixedFeeRule,
+            zip317::{FeeRule as Zip317FeeRule, MINIMUM_FEE},
+            StandardFeeRule,
+        },
         Transaction,
     },
 };
@@ -1582,7 +1586,7 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
     .unwrap();
 
     #[allow(deprecated)]
-    let fee_rule = FixedFeeRule::standard();
+    let fee_rule = FixedFeeRule::non_standard(MINIMUM_FEE);
     let change_strategy = fees::fixed::SingleOutputChangeStrategy::new(
         fee_rule,
         None,

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Eq,
     convert::Infallible,
     hash::Hash,
-    num::{NonZeroU32, NonZeroU8},
+    num::{NonZeroU32, NonZeroU8, NonZeroUsize},
 };
 
 use assert_matches::assert_matches;
@@ -17,7 +17,7 @@ use zcash_primitives::{
     legacy::TransparentAddress,
     transaction::{
         components::amount::NonNegativeAmount,
-        fees::{fixed::FeeRule as FixedFeeRule, StandardFeeRule},
+        fees::{fixed::FeeRule as FixedFeeRule, zip317::FeeRule as Zip317FeeRule, StandardFeeRule},
         Transaction,
     },
 };
@@ -48,9 +48,9 @@ use crate::{
     },
     decrypt_transaction,
     fees::{
-        fixed,
+        self,
         standard::{self, SingleOutputChangeStrategy},
-        DustOutputPolicy,
+        DustOutputPolicy, SplitPolicy,
     },
     scanning::ScanError,
     wallet::{Note, NoteId, OvkPolicy, ReceivedNote},
@@ -314,6 +314,175 @@ pub fn send_single_step_proposed_transfer<T: ShieldedPoolTester>(
         decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, None),
         Ok(_)
     );
+}
+
+pub fn send_with_multiple_change_outputs<T: ShieldedPoolTester>(
+    dsf: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let dfvk = T::test_account_fvk(&st);
+
+    // Add funds to the wallet in a single note
+    let value = Zatoshis::const_from_u64(650_0000);
+    let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+    st.scan_cached_blocks(h, 1);
+
+    // Spendable balance matches total balance
+    assert_eq!(st.get_total_balance(account.id()), value);
+    assert_eq!(st.get_spendable_balance(account.id(), 1), value);
+
+    assert_eq!(
+        st.wallet()
+            .block_max_scanned()
+            .unwrap()
+            .unwrap()
+            .block_height(),
+        h
+    );
+
+    let to_extsk = T::sk(&[0xf5; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(100_0000),
+    )])
+    .unwrap();
+
+    let input_selector = GreedyInputSelector::new();
+    let change_memo = "Test change memo".parse::<Memo>().unwrap();
+    let change_strategy = fees::zip317::MultiOutputChangeStrategy::new(
+        Zip317FeeRule::standard(),
+        Some(change_memo.clone().into()),
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+        SplitPolicy::new(
+            NonZeroUsize::new(2).unwrap(),
+            NonNegativeAmount::const_from_u64(100_0000),
+        ),
+    );
+
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request.clone(),
+            NonZeroU32::new(1).unwrap(),
+        )
+        .unwrap();
+
+    let step = &proposal.steps().head;
+    assert_eq!(step.balance().proposed_change().len(), 2);
+
+    let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    );
+    assert_matches!(&create_proposed_result, Ok(txids) if txids.len() == 1);
+
+    let sent_tx_id = create_proposed_result.unwrap()[0];
+
+    // Verify that the sent transaction was stored and that we can decrypt the memos
+    let tx = st
+        .wallet()
+        .get_transaction(sent_tx_id)
+        .unwrap()
+        .expect("Created transaction was stored.");
+    let ufvks = [(account.id(), account.usk().to_unified_full_viewing_key())]
+        .into_iter()
+        .collect();
+    let d_tx = decrypt_transaction(st.network(), h + 1, &tx, &ufvks);
+    assert_eq!(T::decrypted_pool_outputs_count(&d_tx), 3);
+
+    let mut found_tx_change_memo = false;
+    let mut found_tx_empty_memo = false;
+    T::with_decrypted_pool_memos(&d_tx, |memo| {
+        if Memo::try_from(memo).unwrap() == change_memo {
+            found_tx_change_memo = true
+        }
+        if Memo::try_from(memo).unwrap() == Memo::Empty {
+            found_tx_empty_memo = true
+        }
+    });
+    assert!(found_tx_change_memo);
+    assert!(found_tx_empty_memo);
+
+    // Verify that the stored sent notes match what we're expecting
+    let sent_note_ids = st
+        .wallet()
+        .get_sent_note_ids(&sent_tx_id, T::SHIELDED_PROTOCOL)
+        .unwrap();
+    assert_eq!(sent_note_ids.len(), 3);
+
+    // The sent memo should be the empty memo for the sent output, and the
+    // change output's memo should be as specified.
+    let mut change_memo_count = 0;
+    let mut found_sent_empty_memo = false;
+    for sent_note_id in sent_note_ids {
+        match st
+            .wallet()
+            .get_memo(sent_note_id)
+            .expect("Note id is valid")
+            .as_ref()
+        {
+            Some(m) if m == &change_memo => {
+                change_memo_count += 1;
+            }
+            Some(m) if m == &Memo::Empty => {
+                found_sent_empty_memo = true;
+            }
+            Some(other) => panic!("Unexpected memo value: {:?}", other),
+            None => panic!("Memo should not be stored as NULL"),
+        }
+    }
+    assert_eq!(change_memo_count, 2);
+    assert!(found_sent_empty_memo);
+
+    let tx_history = st.wallet().get_tx_history().unwrap();
+    assert_eq!(tx_history.len(), 2);
+
+    let network = *st.network();
+    assert_matches!(
+        decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, None),
+        Ok(_)
+    );
+
+    let (h, _) = st.generate_next_block_including(sent_tx_id);
+    st.scan_cached_blocks(h, 1);
+
+    // Now, create another proposal with more outputs requested. We have two change notes;
+    // we'll spend one of them, and then we'll generate 7 splits.
+    let change_strategy = fees::zip317::MultiOutputChangeStrategy::new(
+        Zip317FeeRule::standard(),
+        Some(change_memo.into()),
+        T::SHIELDED_PROTOCOL,
+        DustOutputPolicy::default(),
+        SplitPolicy::new(
+            NonZeroUsize::new(8).unwrap(),
+            NonNegativeAmount::const_from_u64(10_0000),
+        ),
+    );
+
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            NonZeroU32::new(1).unwrap(),
+        )
+        .unwrap();
+
+    let step = &proposal.steps().head;
+    assert_eq!(step.balance().proposed_change().len(), 7);
 }
 
 #[cfg(feature = "transparent-inputs")]
@@ -1414,7 +1583,7 @@ pub fn external_address_change_spends_detected_in_restore_from_seed<T: ShieldedP
 
     #[allow(deprecated)]
     let fee_rule = FixedFeeRule::standard();
-    let change_strategy = fixed::SingleOutputChangeStrategy::new(
+    let change_strategy = fees::fixed::SingleOutputChangeStrategy::new(
         fee_rule,
         None,
         T::SHIELDED_PROTOCOL,

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -197,16 +197,23 @@ where
     check_balance(&st, 0, value);
 
     // Shield the output.
-    let input_selector = GreedyInputSelector::new(
-        fixed::SingleOutputChangeStrategy::new(
-            FixedFeeRule::non_standard(NonNegativeAmount::ZERO),
-            None,
-            ShieldedProtocol::Sapling,
-        ),
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy = fixed::SingleOutputChangeStrategy::new(
+        FixedFeeRule::non_standard(NonNegativeAmount::ZERO),
+        None,
+        ShieldedProtocol::Sapling,
         DustOutputPolicy::default(),
     );
     let txid = st
-        .shield_transparent_funds(&input_selector, value, account.usk(), &[*taddr], 1)
+        .shield_transparent_funds(
+            &input_selector,
+            &change_strategy,
+            value,
+            account.usk(),
+            &[*taddr],
+            account.id(),
+            1,
+        )
         .unwrap()[0];
 
     // The wallet should have zero transparent balance, because the shielding

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1,11 +1,12 @@
 use crate::{
     data_api::{
-        testing::{AddressType, TestBuilder, TestState},
-        testing::{DataStoreFactory, ShieldedProtocol, TestCache},
+        testing::{
+            AddressType, DataStoreFactory, ShieldedProtocol, TestBuilder, TestCache, TestState,
+        },
         wallet::input_selection::GreedyInputSelector,
         Account as _, InputSource, WalletRead, WalletWrite,
     },
-    fees::{fixed, DustOutputPolicy},
+    fees::CommonChangeStrategy,
     wallet::WalletTransparentOutput,
 };
 use assert_matches::assert_matches;
@@ -198,12 +199,11 @@ where
 
     // Shield the output.
     let input_selector = GreedyInputSelector::new();
-    let change_strategy = fixed::SingleOutputChangeStrategy::new(
+    let change_strategy = CommonChangeStrategy::simple(
         #[allow(deprecated)]
         FixedFeeRule::non_standard(NonNegativeAmount::ZERO),
         None,
         ShieldedProtocol::Sapling,
-        DustOutputPolicy::default(),
     );
     let txid = st
         .shield_transparent_funds(

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -199,6 +199,7 @@ where
     // Shield the output.
     let input_selector = GreedyInputSelector::new();
     let change_strategy = fixed::SingleOutputChangeStrategy::new(
+        #[allow(deprecated)]
         FixedFeeRule::non_standard(NonNegativeAmount::ZERO),
         None,
         ShieldedProtocol::Sapling,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -115,6 +115,8 @@ where
     Ok(())
 }
 
+/// Errors that may be generated in construction of proposals for shielded->shielded or
+/// shielded->transparent transfers.
 pub type ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error<
     <DbT as WalletRead>::Error,
     CommitmentTreeErrT,
@@ -124,6 +126,8 @@ pub type ProposeTransferErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error<
     <<InputsT as InputSelector>::InputSource as InputSource>::NoteRef,
 >;
 
+/// Errors that may be generated in construction of proposals for transparent->shielded
+/// wallet-internal transfers.
 #[cfg(feature = "transparent-inputs")]
 pub type ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error<
     <DbT as WalletRead>::Error,
@@ -134,6 +138,7 @@ pub type ProposeShieldingErrT<DbT, CommitmentTreeErrT, InputsT, ChangeT> = Error
     Infallible,
 >;
 
+/// Errors that may be generated in combined creation and execution of transaction proposals.
 pub type CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N> = Error<
     <DbT as WalletRead>::Error,
     <DbT as WalletCommitmentTrees>::Error,
@@ -143,6 +148,7 @@ pub type CreateErrT<DbT, InputsErrT, FeeRuleT, ChangeErrT, N> = Error<
     N,
 >;
 
+/// Errors that may be generated in the execution of proposals that may send shielded inputs.
 pub type TransferErrT<DbT, InputsT, ChangeT> = Error<
     <DbT as WalletRead>::Error,
     <DbT as WalletCommitmentTrees>::Error,
@@ -152,6 +158,7 @@ pub type TransferErrT<DbT, InputsT, ChangeT> = Error<
     <<InputsT as InputSelector>::InputSource as InputSource>::NoteRef,
 >;
 
+/// Errors that may be generated in the execution of shielding proposals.
 #[cfg(feature = "transparent-inputs")]
 pub type ShieldErrT<DbT, InputsT, ChangeT> = Error<
     <DbT as WalletRead>::Error,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -323,7 +323,7 @@ where
     let proposal = propose_standard_transfer_to_address(
         wallet_db,
         params,
-        StandardFeeRule::PreZip313,
+        StandardFeeRule::Zip317,
         account.id(),
         min_confirmations,
         to,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -617,7 +617,7 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
                     &orchard_outputs[..],
                 ),
                 ephemeral_balance.as_ref(),
-                Some(&wallet_meta),
+                wallet_meta.as_ref(),
             );
 
             match balance {
@@ -819,7 +819,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             #[cfg(feature = "orchard")]
             &orchard_fees::EmptyBundleView,
             None,
-            Some(&wallet_meta),
+            wallet_meta.as_ref(),
         );
 
         let balance = match trial_balance {
@@ -837,7 +837,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                     #[cfg(feature = "orchard")]
                     &orchard_fees::EmptyBundleView,
                     None,
-                    Some(&wallet_meta),
+                    wallet_meta.as_ref(),
                 )?
             }
             Err(other) => return Err(InputSelectorError::Change(other)),

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -393,13 +393,13 @@ impl SplitPolicy {
                 )
                 .unwrap(),
             );
-            if split_count > NonZeroUsize::MIN
-                && *per_output_change.quotient() < self.min_split_output_size
-            {
-                split_count = NonZeroUsize::new(usize::from(split_count) - 1)
-                    .expect("split_count checked to be > 1");
-            } else {
+            if *per_output_change.quotient() >= self.min_split_output_size {
                 return split_count;
+            } else if let Some(new_count) = NonZeroUsize::new(usize::from(split_count) - 1) {
+                split_count = new_count;
+            } else {
+                // We always create at least one change output.
+                return NonZeroUsize::MIN;
             }
         }
     }

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -203,33 +203,6 @@ pub enum ChangeError<E, NoteRefT> {
     BundleError(&'static str),
 }
 
-impl<E, NoteRefT> ChangeError<E, NoteRefT> {
-    pub(crate) fn map<E0, F: FnOnce(E) -> E0>(self, f: F) -> ChangeError<E0, NoteRefT> {
-        match self {
-            ChangeError::InsufficientFunds {
-                available,
-                required,
-            } => ChangeError::InsufficientFunds {
-                available,
-                required,
-            },
-            ChangeError::DustInputs {
-                transparent,
-                sapling,
-                #[cfg(feature = "orchard")]
-                orchard,
-            } => ChangeError::DustInputs {
-                transparent,
-                sapling,
-                #[cfg(feature = "orchard")]
-                orchard,
-            },
-            ChangeError::StrategyError(e) => ChangeError::StrategyError(f(e)),
-            ChangeError::BundleError(e) => ChangeError::BundleError(e),
-        }
-    }
-}
-
 impl<CE: fmt::Display, N: fmt::Display> fmt::Display for ChangeError<CE, N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -1,4 +1,5 @@
 use core::cmp::{max, min};
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use zcash_primitives::{
     consensus::{self, BlockHeight},
@@ -10,9 +11,11 @@ use zcash_primitives::{
 };
 use zcash_protocol::ShieldedProtocol;
 
+use crate::data_api::WalletMeta;
+
 use super::{
     sapling as sapling_fees, ChangeError, ChangeValue, DustAction, DustOutputPolicy,
-    EphemeralBalance, TransactionBalance,
+    EphemeralBalance, SplitPolicy, TransactionBalance,
 };
 
 #[cfg(feature = "orchard")]
@@ -112,33 +115,26 @@ where
 }
 
 /// Decide which shielded pool change should go to if there is any.
-pub(crate) fn single_change_output_policy(
+pub(crate) fn select_change_pool(
     _net_flows: &NetFlows,
     _fallback_change_pool: ShieldedProtocol,
-) -> (ShieldedProtocol, usize, usize) {
+) -> ShieldedProtocol {
     // TODO: implement a less naive strategy for selecting the pool to which change will be sent.
-    let change_pool = {
-        #[cfg(feature = "orchard")]
-        if _net_flows.orchard_in.is_positive() || _net_flows.orchard_out.is_positive() {
-            // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
-            ShieldedProtocol::Orchard
-        } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
-            // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
-            // Sapling outputs, so that we avoid pool-crossing.
-            ShieldedProtocol::Sapling
-        } else {
-            // The flows are transparent, so there may not be change. If there is, the caller
-            // gets to decide where to shield it.
-            _fallback_change_pool
-        }
-        #[cfg(not(feature = "orchard"))]
+    #[cfg(feature = "orchard")]
+    if _net_flows.orchard_in.is_positive() || _net_flows.orchard_out.is_positive() {
+        // Send change to Orchard if we're spending any Orchard inputs or creating any Orchard outputs.
+        ShieldedProtocol::Orchard
+    } else if _net_flows.sapling_in.is_positive() || _net_flows.sapling_out.is_positive() {
+        // Otherwise, send change to Sapling if we're spending any Sapling inputs or creating any
+        // Sapling outputs, so that we avoid pool-crossing.
         ShieldedProtocol::Sapling
-    };
-    (
-        change_pool,
-        (change_pool == ShieldedProtocol::Sapling).into(),
-        (change_pool == ShieldedProtocol::Orchard).into(),
-    )
+    } else {
+        // The flows are transparent, so there may not be change. If there is, the caller
+        // gets to decide where to shield it.
+        _fallback_change_pool
+    }
+    #[cfg(not(feature = "orchard"))]
+    ShieldedProtocol::Sapling
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -162,6 +158,10 @@ impl OutputManifest {
     pub(crate) fn orchard(&self) -> usize {
         self.orchard
     }
+
+    pub(crate) fn total_shielded(&self) -> usize {
+        self.sapling + self.orchard
+    }
 }
 
 pub(crate) struct SinglePoolBalanceConfig<'a, P, F> {
@@ -169,17 +169,20 @@ pub(crate) struct SinglePoolBalanceConfig<'a, P, F> {
     fee_rule: &'a F,
     dust_output_policy: &'a DustOutputPolicy,
     default_dust_threshold: NonNegativeAmount,
+    split_policy: &'a SplitPolicy,
     fallback_change_pool: ShieldedProtocol,
     marginal_fee: NonNegativeAmount,
     grace_actions: usize,
 }
 
 impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         params: &'a P,
         fee_rule: &'a F,
         dust_output_policy: &'a DustOutputPolicy,
         default_dust_threshold: NonNegativeAmount,
+        split_policy: &'a SplitPolicy,
         fallback_change_pool: ShieldedProtocol,
         marginal_fee: NonNegativeAmount,
         grace_actions: usize,
@@ -189,6 +192,7 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
             fee_rule,
             dust_output_policy,
             default_dust_threshold,
+            split_policy,
             fallback_change_pool,
             marginal_fee,
             grace_actions,
@@ -197,13 +201,9 @@ impl<'a, P, F> SinglePoolBalanceConfig<'a, P, F> {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn single_change_output_balance<
-    P: consensus::Parameters,
-    NoteRefT: Clone,
-    F: FeeRule,
-    E,
->(
+pub(crate) fn single_pool_output_balance<P: consensus::Parameters, NoteRefT: Clone, F: FeeRule, E>(
     cfg: SinglePoolBalanceConfig<P, F>,
+    wallet_meta: Option<&WalletMeta>,
     target_height: BlockHeight,
     transparent_inputs: &[impl transparent::InputView],
     transparent_outputs: &[impl transparent::OutputView],
@@ -232,9 +232,32 @@ where
         ephemeral_balance,
     )?;
 
-    #[allow(unused_variables)]
-    let (change_pool, sapling_change, orchard_change) =
-        single_change_output_policy(&net_flows, cfg.fallback_change_pool);
+    let change_pool = select_change_pool(&net_flows, cfg.fallback_change_pool);
+    let target_change_counts = OutputManifest {
+        transparent: 0,
+        sapling: if change_pool == ShieldedProtocol::Sapling {
+            wallet_meta.map_or(1, |m| {
+                std::cmp::max(
+                    usize::from(cfg.split_policy.target_output_count)
+                        .saturating_sub(m.total_note_count()),
+                    1,
+                )
+            })
+        } else {
+            0
+        },
+        orchard: if change_pool == ShieldedProtocol::Orchard {
+            wallet_meta.map_or(1, |m| {
+                std::cmp::max(
+                    usize::from(cfg.split_policy.target_output_count)
+                        .saturating_sub(m.total_note_count()),
+                    1,
+                )
+            })
+        } else {
+            0
+        },
+    };
 
     // We don't create a fully-transparent transaction if a change memo is used.
     let transparent = net_flows.is_transparent() && change_memo.is_none();
@@ -246,20 +269,17 @@ where
         // Is it certain that there will be a change output? If it is not certain,
         // we should call `check_for_uneconomic_inputs` with `possible_change`
         // including both possibilities.
-        let possible_change =
+        let possible_change = {
             // These are the situations where we might not have a change output.
-            if transparent || (cfg.dust_output_policy.action() == DustAction::AddDustToFee && change_memo.is_none()) {
-                vec![
-                    OutputManifest::ZERO,
-                    OutputManifest {
-                        transparent: 0,
-                        sapling: sapling_change,
-                        orchard: orchard_change
-                    }
-                ]
+            if transparent
+                || (cfg.dust_output_policy.action() == DustAction::AddDustToFee
+                    && change_memo.is_none())
+            {
+                vec![OutputManifest::ZERO, target_change_counts]
             } else {
-                vec![OutputManifest { transparent: 0, sapling: sapling_change, orchard: orchard_change}]
-            };
+                vec![target_change_counts]
+            }
+        };
 
         check_for_uneconomic_inputs(
             transparent_inputs,
@@ -285,35 +305,36 @@ where
         .bundle_type()
         .num_spends(sapling.inputs().len())
         .map_err(ChangeError::BundleError)?;
-    let sapling_output_count = sapling
-        .bundle_type()
-        .num_outputs(sapling.inputs().len(), sapling.outputs().len())
-        .map_err(ChangeError::BundleError)?;
-    let sapling_output_count_with_change = sapling
-        .bundle_type()
-        .num_outputs(
-            sapling.inputs().len(),
-            sapling.outputs().len() + sapling_change,
-        )
-        .map_err(ChangeError::BundleError)?;
+    let sapling_output_count = |change_count| {
+        sapling
+            .bundle_type()
+            .num_outputs(
+                sapling.inputs().len(),
+                sapling.outputs().len() + change_count,
+            )
+            .map_err(ChangeError::BundleError)
+    };
 
     #[cfg(feature = "orchard")]
-    let orchard_action_count = orchard
-        .bundle_type()
-        .num_actions(orchard.inputs().len(), orchard.outputs().len())
-        .map_err(ChangeError::BundleError)?;
-    #[cfg(feature = "orchard")]
-    let orchard_action_count_with_change = orchard
-        .bundle_type()
-        .num_actions(
-            orchard.inputs().len(),
-            orchard.outputs().len() + orchard_change,
-        )
-        .map_err(ChangeError::BundleError)?;
+    let orchard_action_count = |change_count| {
+        orchard
+            .bundle_type()
+            .num_actions(
+                orchard.inputs().len(),
+                orchard.outputs().len() + change_count,
+            )
+            .map_err(ChangeError::BundleError)
+    };
     #[cfg(not(feature = "orchard"))]
-    let orchard_action_count = 0;
-    #[cfg(not(feature = "orchard"))]
-    let orchard_action_count_with_change = 0;
+    let orchard_action_count = |change_count: usize| -> Result<usize, ChangeError<E, NoteRefT>> {
+        if change_count != 0 {
+            Err(ChangeError::BundleError(
+                "Nonzero Orchard change requested but the `orchard` feature is not enabled.",
+            ))
+        } else {
+            Ok(0)
+        }
+    };
 
     // Once we calculate the balance with and without change, there are five cases:
     //
@@ -365,8 +386,8 @@ where
             transparent_input_sizes.clone(),
             transparent_output_sizes.clone(),
             sapling_input_count,
-            sapling_output_count,
-            orchard_action_count,
+            sapling_output_count(0)?,
+            orchard_action_count(0)?,
         )
         .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?;
 
@@ -376,11 +397,11 @@ where
             .fee_required(
                 cfg.params,
                 target_height,
-                transparent_input_sizes,
-                transparent_output_sizes,
+                transparent_input_sizes.clone(),
+                transparent_output_sizes.clone(),
                 sapling_input_count,
-                sapling_output_count_with_change,
-                orchard_action_count_with_change,
+                sapling_output_count(target_change_counts.sapling())?,
+                orchard_action_count(target_change_counts.orchard())?,
             )
             .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?,
     );
@@ -410,13 +431,73 @@ where
             // Case 3b or 3c.
             let proposed_change =
                 (total_in - total_out_plus_fee_with_change).expect("checked above");
+
+            // We obtain a split count based on the total number of notes of sufficient size
+            // available in the wallet, irrespective of pool. If we don't have any wallet metadata
+            // available, we fall back to generating a single change output.
+            let split_count = wallet_meta.map_or(NonZeroUsize::MIN, |wm| {
+                cfg.split_policy
+                    .split_count(wm.total_note_count(), proposed_change)
+            });
+            let per_output_change = proposed_change.div_with_remainder(
+                NonZeroU64::new(
+                    u64::try_from(usize::from(split_count)).expect("usize fits into u64"),
+                )
+                .unwrap(),
+            );
+
+            // If we don't have as many change outputs as we expected, recompute the fee.
+            let (fee_with_change, excess_fee) =
+                if usize::from(split_count) < target_change_counts.total_shielded() {
+                    let new_fee_with_change = cfg
+                        .fee_rule
+                        .fee_required(
+                            cfg.params,
+                            target_height,
+                            transparent_input_sizes,
+                            transparent_output_sizes,
+                            sapling_input_count,
+                            sapling_output_count(if change_pool == ShieldedProtocol::Sapling {
+                                usize::from(split_count)
+                            } else {
+                                0
+                            })?,
+                            orchard_action_count(if change_pool == ShieldedProtocol::Orchard {
+                                usize::from(split_count)
+                            } else {
+                                0
+                            })?,
+                        )
+                        .map_err(|fee_error| ChangeError::StrategyError(E::from(fee_error)))?;
+                    (
+                        new_fee_with_change,
+                        (fee_with_change - new_fee_with_change).unwrap_or(NonNegativeAmount::ZERO),
+                    )
+                } else {
+                    (fee_with_change, NonNegativeAmount::ZERO)
+                };
+
             let simple_case = || {
                 (
-                    vec![ChangeValue::shielded(
-                        change_pool,
-                        proposed_change,
-                        change_memo.cloned(),
-                    )],
+                    (0usize..split_count.into())
+                        .map(|i| {
+                            ChangeValue::shielded(
+                                change_pool,
+                                if i == 0 {
+                                    // Add any remainder to the first output only
+                                    (*per_output_change.quotient()
+                                        + *per_output_change.remainder()
+                                        + excess_fee)
+                                        .unwrap()
+                                } else {
+                                    // For any other output, the change value will just be the
+                                    // quotient.
+                                    *per_output_change.quotient()
+                                },
+                                change_memo.cloned(),
+                            )
+                        })
+                        .collect(),
                     fee_with_change,
                 )
             };
@@ -426,7 +507,7 @@ where
                 .dust_threshold()
                 .unwrap_or(cfg.default_dust_threshold);
 
-            if proposed_change < change_dust_threshold {
+            if per_output_change.quotient() < &change_dust_threshold {
                 match cfg.dust_output_policy.action() {
                     DustAction::Reject => {
                         // Always allow zero-valued change even for the `Reject` policy:
@@ -435,11 +516,11 @@ where
                         // * this case occurs in practice when sending all funds from an account;
                         // * zero-valued notes do not require witness tracking;
                         // * the effect on trial decryption overhead is small.
-                        if proposed_change.is_zero() {
+                        if per_output_change.quotient().is_zero() {
                             simple_case()
                         } else {
-                            let shortfall =
-                                (change_dust_threshold - proposed_change).ok_or_else(underflow)?;
+                            let shortfall = (change_dust_threshold - *per_output_change.quotient())
+                                .ok_or_else(underflow)?;
 
                             return Err(ChangeError::InsufficientFunds {
                                 available: total_in,

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -233,27 +233,20 @@ where
     )?;
 
     let change_pool = select_change_pool(&net_flows, cfg.fallback_change_pool);
+    let target_change_count = wallet_meta.map_or(1, |m| {
+        usize::from(cfg.split_policy.target_output_count)
+            .saturating_sub(m.total_note_count())
+            .max(1)
+    });
     let target_change_counts = OutputManifest {
         transparent: 0,
         sapling: if change_pool == ShieldedProtocol::Sapling {
-            wallet_meta.map_or(1, |m| {
-                std::cmp::max(
-                    usize::from(cfg.split_policy.target_output_count)
-                        .saturating_sub(m.total_note_count()),
-                    1,
-                )
-            })
+            target_change_count
         } else {
             0
         },
         orchard: if change_pool == ShieldedProtocol::Orchard {
-            wallet_meta.map_or(1, |m| {
-                std::cmp::max(
-                    usize::from(cfg.split_policy.target_output_count)
-                        .saturating_sub(m.total_note_count()),
-                    1,
-                )
-            })
+            target_change_count
         } else {
             0
         },

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -119,7 +119,7 @@ mod tests {
         consensus::{Network, NetworkUpgrade, Parameters},
         transaction::{
             components::{amount::NonNegativeAmount, transparent::TxOut},
-            fees::fixed::FeeRule as FixedFeeRule,
+            fees::{fixed::FeeRule as FixedFeeRule, zip317::MINIMUM_FEE},
         },
     };
 
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn change_without_dust() {
         #[allow(deprecated)]
-        let fee_rule = FixedFeeRule::standard();
+        let fee_rule = FixedFeeRule::non_standard(MINIMUM_FEE);
         let change_strategy = SingleOutputChangeStrategy::<MockWalletDb>::new(
             fee_rule,
             None,
@@ -175,14 +175,14 @@ mod tests {
             result,
             Ok(balance) if
                 balance.proposed_change() == [ChangeValue::sapling(NonNegativeAmount::const_from_u64(10000), None)] &&
-                balance.fee_required() == NonNegativeAmount::const_from_u64(10000)
+                balance.fee_required() == MINIMUM_FEE
         );
     }
 
     #[test]
     fn dust_change() {
         #[allow(deprecated)]
-        let fee_rule = FixedFeeRule::standard();
+        let fee_rule = FixedFeeRule::non_standard(MINIMUM_FEE);
         let change_strategy = SingleOutputChangeStrategy::<MockWalletDb>::new(
             fee_rule,
             None,

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -14,8 +14,9 @@ use zcash_primitives::{
 use crate::{data_api::InputSource, ShieldedProtocol};
 
 use super::{
-    common::single_change_output_balance, sapling as sapling_fees, ChangeError, ChangeStrategy,
-    DustOutputPolicy, EphemeralBalance, TransactionBalance,
+    common::{single_change_output_balance, SinglePoolBalanceConfig},
+    sapling as sapling_fees, ChangeError, ChangeStrategy, DustOutputPolicy, EphemeralBalance,
+    TransactionBalance,
 };
 
 #[cfg(feature = "orchard")]
@@ -85,21 +86,25 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         ephemeral_balance: Option<&EphemeralBalance>,
         _wallet_meta: Option<&Self::WalletMeta>,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
-        single_change_output_balance(
+        let cfg = SinglePoolBalanceConfig::new(
             params,
             &self.fee_rule,
+            &self.dust_output_policy,
+            self.fee_rule.fixed_fee(),
+            self.fallback_change_pool,
+            NonNegativeAmount::ZERO,
+            0,
+        );
+
+        single_change_output_balance(
+            cfg,
             target_height,
             transparent_inputs,
             transparent_outputs,
             sapling,
             #[cfg(feature = "orchard")]
             orchard,
-            &self.dust_output_policy,
-            self.fee_rule.fixed_fee(),
             self.change_memo.as_ref(),
-            self.fallback_change_pool,
-            NonNegativeAmount::ZERO,
-            0,
             ephemeral_balance,
         )
     }

--- a/zcash_client_backend/src/fees/fixed.rs
+++ b/zcash_client_backend/src/fees/fixed.rs
@@ -14,9 +14,9 @@ use zcash_primitives::{
 use crate::{data_api::InputSource, ShieldedProtocol};
 
 use super::{
-    common::{single_change_output_balance, SinglePoolBalanceConfig},
+    common::{single_pool_output_balance, SinglePoolBalanceConfig},
     sapling as sapling_fees, ChangeError, ChangeStrategy, DustOutputPolicy, EphemeralBalance,
-    TransactionBalance,
+    SplitPolicy, TransactionBalance,
 };
 
 #[cfg(feature = "orchard")]
@@ -86,18 +86,21 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         ephemeral_balance: Option<&EphemeralBalance>,
         _wallet_meta: Option<&Self::WalletMeta>,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
+        let split_policy = SplitPolicy::single_output();
         let cfg = SinglePoolBalanceConfig::new(
             params,
             &self.fee_rule,
             &self.dust_output_policy,
             self.fee_rule.fixed_fee(),
+            &split_policy,
             self.fallback_change_pool,
             NonNegativeAmount::ZERO,
             0,
         );
 
-        single_change_output_balance(
+        single_pool_output_balance(
             cfg,
+            None,
             target_height,
             transparent_inputs,
             transparent_outputs,

--- a/zcash_client_backend/src/fees/standard.rs
+++ b/zcash_client_backend/src/fees/standard.rs
@@ -1,5 +1,7 @@
 //! Change strategies designed for use with a standard fee.
 
+use std::marker::PhantomData;
+
 use zcash_primitives::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
@@ -14,7 +16,7 @@ use zcash_primitives::{
     },
 };
 
-use crate::ShieldedProtocol;
+use crate::{data_api::InputSource, ShieldedProtocol};
 
 use super::{
     fixed, sapling as sapling_fees, zip317, ChangeError, ChangeStrategy, DustOutputPolicy,
@@ -28,13 +30,15 @@ use super::orchard as orchard_fees;
 /// as the most current pool that avoids unnecessary pool-crossing (with a specified
 /// fallback when the transaction has no shielded inputs). Fee calculation is delegated
 /// to the provided fee rule.
-pub struct SingleOutputChangeStrategy {
+pub struct SingleOutputChangeStrategy<I> {
     fee_rule: StandardFeeRule,
     change_memo: Option<MemoBytes>,
     fallback_change_pool: ShieldedProtocol,
+    dust_output_policy: DustOutputPolicy,
+    meta_source: PhantomData<I>,
 }
 
-impl SingleOutputChangeStrategy {
+impl<I> SingleOutputChangeStrategy<I> {
     /// Constructs a new [`SingleOutputChangeStrategy`] with the specified ZIP 317
     /// fee parameters.
     ///
@@ -44,21 +48,35 @@ impl SingleOutputChangeStrategy {
         fee_rule: StandardFeeRule,
         change_memo: Option<MemoBytes>,
         fallback_change_pool: ShieldedProtocol,
+        dust_output_policy: DustOutputPolicy,
     ) -> Self {
         Self {
             fee_rule,
             change_memo,
             fallback_change_pool,
+            dust_output_policy,
+            meta_source: PhantomData,
         }
     }
 }
 
-impl ChangeStrategy for SingleOutputChangeStrategy {
+impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
     type FeeRule = StandardFeeRule;
     type Error = Zip317FeeError;
+    type MetaSource = I;
+    type WalletMeta = ();
 
     fn fee_rule(&self) -> &Self::FeeRule {
         &self.fee_rule
+    }
+
+    fn fetch_wallet_meta(
+        &self,
+        _meta_source: &Self::MetaSource,
+        _account: <Self::MetaSource as InputSource>::AccountId,
+        _exclude: &[<Self::MetaSource as crate::data_api::InputSource>::NoteRef],
+    ) -> Result<Self::WalletMeta, <Self::MetaSource as crate::data_api::InputSource>::Error> {
+        Ok(())
     }
 
     fn compute_balance<P: consensus::Parameters, NoteRefT: Clone>(
@@ -69,15 +87,16 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
         transparent_outputs: &[impl transparent::OutputView],
         sapling: &impl sapling_fees::BundleView<NoteRefT>,
         #[cfg(feature = "orchard")] orchard: &impl orchard_fees::BundleView<NoteRefT>,
-        dust_output_policy: &DustOutputPolicy,
         ephemeral_balance: Option<&EphemeralBalance>,
+        wallet_meta: Option<&Self::WalletMeta>,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
         #[allow(deprecated)]
         match self.fee_rule() {
-            StandardFeeRule::PreZip313 => fixed::SingleOutputChangeStrategy::new(
+            StandardFeeRule::PreZip313 => fixed::SingleOutputChangeStrategy::<I>::new(
                 FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(10000)),
                 self.change_memo.clone(),
                 self.fallback_change_pool,
+                self.dust_output_policy,
             )
             .compute_balance(
                 params,
@@ -87,14 +106,15 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
                 sapling,
                 #[cfg(feature = "orchard")]
                 orchard,
-                dust_output_policy,
                 ephemeral_balance,
+                wallet_meta,
             )
             .map_err(|e| e.map(Zip317FeeError::Balance)),
-            StandardFeeRule::Zip313 => fixed::SingleOutputChangeStrategy::new(
+            StandardFeeRule::Zip313 => fixed::SingleOutputChangeStrategy::<I>::new(
                 FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(1000)),
                 self.change_memo.clone(),
                 self.fallback_change_pool,
+                self.dust_output_policy,
             )
             .compute_balance(
                 params,
@@ -104,14 +124,15 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
                 sapling,
                 #[cfg(feature = "orchard")]
                 orchard,
-                dust_output_policy,
                 ephemeral_balance,
+                wallet_meta,
             )
             .map_err(|e| e.map(Zip317FeeError::Balance)),
-            StandardFeeRule::Zip317 => zip317::SingleOutputChangeStrategy::new(
+            StandardFeeRule::Zip317 => zip317::SingleOutputChangeStrategy::<I>::new(
                 Zip317FeeRule::standard(),
                 self.change_memo.clone(),
                 self.fallback_change_pool,
+                self.dust_output_policy,
             )
             .compute_balance(
                 params,
@@ -121,8 +142,8 @@ impl ChangeStrategy for SingleOutputChangeStrategy {
                 sapling,
                 #[cfg(feature = "orchard")]
                 orchard,
-                dust_output_policy,
                 ephemeral_balance,
+                wallet_meta,
             ),
         }
     }

--- a/zcash_client_backend/src/fees/standard.rs
+++ b/zcash_client_backend/src/fees/standard.rs
@@ -5,21 +5,17 @@ use std::marker::PhantomData;
 use zcash_primitives::{
     consensus::{self, BlockHeight},
     memo::MemoBytes,
-    transaction::{
-        components::amount::NonNegativeAmount,
-        fees::{
-            fixed::FeeRule as FixedFeeRule,
-            transparent,
-            zip317::{FeeError as Zip317FeeError, FeeRule as Zip317FeeRule},
-            StandardFeeRule,
-        },
+    transaction::fees::{
+        transparent,
+        zip317::{FeeError as Zip317FeeError, FeeRule as Zip317FeeRule},
+        StandardFeeRule,
     },
 };
 
 use crate::{data_api::InputSource, ShieldedProtocol};
 
 use super::{
-    fixed, sapling as sapling_fees, zip317, ChangeError, ChangeStrategy, DustOutputPolicy,
+    sapling as sapling_fees, zip317, ChangeError, ChangeStrategy, DustOutputPolicy,
     EphemeralBalance, TransactionBalance,
 };
 
@@ -90,44 +86,7 @@ impl<I: InputSource> ChangeStrategy for SingleOutputChangeStrategy<I> {
         ephemeral_balance: Option<&EphemeralBalance>,
         wallet_meta: Option<&Self::WalletMeta>,
     ) -> Result<TransactionBalance, ChangeError<Self::Error, NoteRefT>> {
-        #[allow(deprecated)]
         match self.fee_rule() {
-            StandardFeeRule::PreZip313 => fixed::SingleOutputChangeStrategy::<I>::new(
-                FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(10000)),
-                self.change_memo.clone(),
-                self.fallback_change_pool,
-                self.dust_output_policy,
-            )
-            .compute_balance(
-                params,
-                target_height,
-                transparent_inputs,
-                transparent_outputs,
-                sapling,
-                #[cfg(feature = "orchard")]
-                orchard,
-                ephemeral_balance,
-                wallet_meta,
-            )
-            .map_err(|e| e.map(Zip317FeeError::Balance)),
-            StandardFeeRule::Zip313 => fixed::SingleOutputChangeStrategy::<I>::new(
-                FixedFeeRule::non_standard(NonNegativeAmount::const_from_u64(1000)),
-                self.change_memo.clone(),
-                self.fallback_change_pool,
-                self.dust_output_policy,
-            )
-            .compute_balance(
-                params,
-                target_height,
-                transparent_inputs,
-                transparent_outputs,
-                sapling,
-                #[cfg(feature = "orchard")]
-                orchard,
-                ephemeral_balance,
-                wallet_meta,
-            )
-            .map_err(|e| e.map(Zip317FeeError::Balance)),
             StandardFeeRule::Zip317 => zip317::SingleOutputChangeStrategy::<I>::new(
                 Zip317FeeRule::standard(),
                 self.change_memo.clone(),

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -139,10 +139,10 @@ impl<I> MultiOutputChangeStrategy<I> {
     /// change value is available to create notes with at least the minimum value dictated by the
     /// split policy.
     ///
-    /// `fallback_change_pool`: the pool to which change will be sent if when more than one
-    /// shielded pool is enabled via feature flags, and the transaction has no shielded inputs.
-    /// `split_policy`: A policy value describing how the change value should be returned as
-    /// multiple notes.
+    /// - `fallback_change_pool`: the pool to which change will be sent if when more than one
+    ///   shielded pool is enabled via feature flags, and the transaction has no shielded inputs.
+    /// - `split_policy`: A policy value describing how the change value should be returned as
+    ///   multiple notes.
     pub fn new(
         fee_rule: Zip317FeeRule,
         change_memo: Option<MemoBytes>,

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -126,7 +126,7 @@ impl Display for ProposalError {
             #[cfg(feature = "transparent-inputs")]
             ProposalError::EphemeralOutputsInvalid => write!(
                 f,
-                "The change strategy provided to input selection failed to correctly generate an ephemeral change output when needed for sending to a TEX address."
+                "The proposal generator failed to correctly generate an ephemeral change output when needed for sending to a TEX address."
             ),
         }
     }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -354,12 +354,16 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
         min_value: NonNegativeAmount,
         exclude: &[Self::NoteRef],
     ) -> Result<WalletMeta, Self::Error> {
+        let chain_tip_height = wallet::chain_tip_height(self.conn.borrow())?
+            .ok_or(SqliteClientError::ChainHeightUnknown)?;
+
         let sapling_note_count = count_outputs(
             self.conn.borrow(),
             account_id,
             min_value,
             exclude,
             ShieldedProtocol::Sapling,
+            chain_tip_height,
         )?;
 
         #[cfg(feature = "orchard")]
@@ -369,6 +373,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
             min_value,
             exclude,
             ShieldedProtocol::Orchard,
+            chain_tip_height,
         )?;
 
         Ok(WalletMeta::new(

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -353,7 +353,7 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
         account_id: Self::AccountId,
         min_value: NonNegativeAmount,
         exclude: &[Self::NoteRef],
-    ) -> Result<WalletMeta, Self::Error> {
+    ) -> Result<Option<WalletMeta>, Self::Error> {
         let chain_tip_height = wallet::chain_tip_height(self.conn.borrow())?
             .ok_or(SqliteClientError::ChainHeightUnknown)?;
 
@@ -376,11 +376,11 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters> InputSource for 
             chain_tip_height,
         )?;
 
-        Ok(WalletMeta::new(
+        Ok(Some(WalletMeta::new(
             sapling_note_count,
             #[cfg(feature = "orchard")]
             orchard_note_count,
-        ))
+        )))
     }
 }
 

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -36,6 +36,13 @@ pub(crate) fn send_single_step_proposed_transfer<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn send_with_multiple_change_outputs<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::send_with_multiple_change_outputs::<T>(
+        TestDbFactory,
+        BlockCache::new(),
+    )
+}
+
 #[cfg(feature = "transparent-inputs")]
 pub(crate) fn send_multi_step_proposed_transfer<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::send_multi_step_proposed_transfer::<T, _>(

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -118,7 +118,7 @@ pub(crate) fn external_address_change_spends_detected_in_restore_from_seed<
 
 #[allow(dead_code)]
 pub(crate) fn zip317_spend<T: ShieldedPoolTester>() {
-    zcash_client_backend::data_api::testing::pool::zip317_spend::<T>(
+    zcash_client_backend::data_api::testing::pool::zip317_spend::<T, TestDbFactory>(
         TestDbFactory,
         BlockCache::new(),
     )

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -65,6 +65,7 @@
 //! - `memo` the shielded memo associated with the output, if any.
 
 use incrementalmerkletree::{Marking, Retention};
+
 use rusqlite::{self, named_params, params, OptionalExtension};
 use secrecy::{ExposeSecret, SecretVec};
 use shardtree::{error::ShardTreeError, store::ShardStore, ShardTree};
@@ -78,6 +79,7 @@ use std::convert::TryFrom;
 use std::io::{self, Cursor};
 use std::num::NonZeroU32;
 use std::ops::RangeInclusive;
+
 use tracing::{debug, warn};
 
 use zcash_address::ZcashAddress;

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -232,6 +232,7 @@ pub(crate) fn count_outputs(
     min_value: NonNegativeAmount,
     exclude: &[ReceivedNoteId],
     protocol: ShieldedProtocol,
+    chain_tip_height: BlockHeight,
 ) -> Result<usize, rusqlite::Error> {
     let (table_prefix, _, _) = per_protocol_names(protocol);
 
@@ -265,13 +266,14 @@ pub(crate) fn count_outputs(
                JOIN transactions stx ON stx.id_tx = transaction_id
                WHERE stx.block IS NOT NULL -- the spending tx is mined
                OR stx.expiry_height IS NULL -- the spending tx will not expire
-               OR stx.expiry_height > :anchor_height -- the spending tx is unexpired
+               OR stx.expiry_height > :chain_tip_height -- the spending tx is unexpired
              )"
         ),
         named_params![
             ":account_id": account.0,
             ":min_value": u64::from(min_value),
-            ":exclude": &excluded_ptr
+            ":exclude": &excluded_ptr,
+            ":chain_tip_height": u32::from(chain_tip_height)
         ],
         |row| row.get(0),
     )

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -405,6 +405,7 @@ mod tests {
                 OsRng,
                 &prover,
                 &prover,
+                #[allow(deprecated)]
                 &fixed::FeeRule::non_standard(NonNegativeAmount::ZERO),
             )
             .unwrap();

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -400,6 +400,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn send_with_multiple_change_outputs() {
+        testing::pool::send_with_multiple_change_outputs::<SaplingPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn send_multi_step_proposed_transfer() {
         testing::pool::send_multi_step_proposed_transfer::<OrchardPoolTester>()

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -413,6 +413,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn send_with_multiple_change_outputs() {
+        testing::pool::send_with_multiple_change_outputs::<SaplingPoolTester>()
+    }
+
+    #[test]
     #[cfg(feature = "transparent-inputs")]
     fn send_multi_step_proposed_transfer() {
         testing::pool::send_multi_step_proposed_transfer::<SaplingPoolTester>()

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -1779,20 +1779,21 @@ pub(crate) mod tests {
             fee_rule,
             Some(change_memo.into()),
             OrchardPoolTester::SHIELDED_PROTOCOL,
+            DustOutputPolicy::default(),
         );
-        let input_selector =
-            &GreedyInputSelector::new(change_strategy, DustOutputPolicy::default());
+        let input_selector = GreedyInputSelector::new();
 
         let proposal = st
             .propose_transfer(
                 account.id(),
-                input_selector,
+                &input_selector,
+                &change_strategy,
                 request,
                 NonZeroU32::new(10).unwrap(),
             )
             .unwrap();
 
-        let create_proposed_result = st.create_proposed_transactions::<Infallible, _>(
+        let create_proposed_result = st.create_proposed_transactions::<Infallible, _, Infallible>(
             account.usk(),
             OvkPolicy::Sender,
             &proposal,
@@ -1867,13 +1868,14 @@ pub(crate) mod tests {
             fee_rule,
             Some(change_memo.into()),
             OrchardPoolTester::SHIELDED_PROTOCOL,
+            DustOutputPolicy::default(),
         );
-        let input_selector =
-            &GreedyInputSelector::new(change_strategy, DustOutputPolicy::default());
+        let input_selector = GreedyInputSelector::new();
 
         let proposal = st.propose_transfer(
             account.id(),
-            input_selector,
+            &input_selector,
+            &change_strategy,
             request.clone(),
             NonZeroU32::new(10).unwrap(),
         );
@@ -1886,7 +1888,8 @@ pub(crate) mod tests {
         // Verify that it's now possible to create the proposal
         let proposal = st.propose_transfer(
             account.id(),
-            input_selector,
+            &input_selector,
+            &change_strategy,
             request,
             NonZeroU32::new(10).unwrap(),
         );

--- a/zcash_client_sqlite/src/wallet/scanning.rs
+++ b/zcash_client_sqlite/src/wallet/scanning.rs
@@ -599,7 +599,6 @@ pub(crate) mod tests {
                 testing::orchard::OrchardPoolTester, wallet::input_selection::GreedyInputSelector,
                 WalletCommitmentTrees,
             },
-            fees::{standard, DustOutputPolicy},
             wallet::OvkPolicy,
         },
         zcash_primitives::{memo::Memo, transaction::fees::StandardFeeRule},
@@ -1713,7 +1712,7 @@ pub(crate) mod tests {
     #[test]
     #[cfg(feature = "orchard")]
     fn orchard_block_spanning_tip_boundary_complete() {
-        use zcash_client_backend::data_api::Account as _;
+        use zcash_client_backend::{data_api::Account as _, fees::CommonChangeStrategy};
 
         let mut st = prepare_orchard_block_spanning_test(true);
         let account = st.test_account().cloned().unwrap();
@@ -1775,11 +1774,10 @@ pub(crate) mod tests {
         let fee_rule = StandardFeeRule::Zip317;
 
         let change_memo = "Test change memo".parse::<Memo>().unwrap();
-        let change_strategy = standard::SingleOutputChangeStrategy::new(
+        let change_strategy = CommonChangeStrategy::simple(
             fee_rule,
             Some(change_memo.into()),
             OrchardPoolTester::SHIELDED_PROTOCOL,
-            DustOutputPolicy::default(),
         );
         let input_selector = GreedyInputSelector::new();
 
@@ -1806,7 +1804,7 @@ pub(crate) mod tests {
     #[test]
     #[cfg(feature = "orchard")]
     fn orchard_block_spanning_tip_boundary_incomplete() {
-        use zcash_client_backend::data_api::Account as _;
+        use zcash_client_backend::{data_api::Account as _, fees::CommonChangeStrategy};
 
         let mut st = prepare_orchard_block_spanning_test(false);
         let account = st.test_account().cloned().unwrap();
@@ -1864,11 +1862,10 @@ pub(crate) mod tests {
         let fee_rule = StandardFeeRule::Zip317;
 
         let change_memo = "Test change memo".parse::<Memo>().unwrap();
-        let change_strategy = standard::SingleOutputChangeStrategy::new(
+        let change_strategy = CommonChangeStrategy::simple(
             fee_rule,
             Some(change_memo.into()),
             OrchardPoolTester::SHIELDED_PROTOCOL,
-            DustOutputPolicy::default(),
         );
         let input_selector = GreedyInputSelector::new();
 

--- a/zcash_extensions/src/transparent/demo.rs
+++ b/zcash_extensions/src/transparent/demo.rs
@@ -493,7 +493,7 @@ mod tests {
                 amount::{Amount, NonNegativeAmount},
                 tze::{Authorized, Bundle, OutPoint, TzeIn, TzeOut},
             },
-            fees::fixed,
+            fees::{fixed, zip317::MINIMUM_FEE},
             Transaction, TransactionData, TxVersion,
         },
     };
@@ -794,7 +794,7 @@ mod tests {
 
         // FIXME: implement zcash_primitives::transaction::fees::FutureFeeRule for zip317::FeeRule.
         #[allow(deprecated)]
-        let fee_rule = fixed::FeeRule::standard();
+        let fee_rule = fixed::FeeRule::non_standard(MINIMUM_FEE);
 
         // create some inputs to spend
         let extsk = ExtendedSpendingKey::master(&[]);

--- a/zcash_keys/src/keys.rs
+++ b/zcash_keys/src/keys.rs
@@ -1723,6 +1723,7 @@ mod tests {
         fn prop_usk_roundtrip(usk in arb_unified_spending_key(zcash_protocol::consensus::Network::MainNetwork)) {
             let encoded = usk.to_bytes(Era::Orchard);
 
+            #[allow(clippy::let_and_return)]
             let encoded_len = {
                 let len = 4;
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `zcash_primitives::transaction::fees::FeeRule` trait has additional
+  `default_dust_threshold`, `marginal_fee`, and `grace_actions` methods, and
+  a `FeeRuleOrBalanceError` associated type.
+
 ### Deprecated
 - `zcash_primitives::transaction::fees`:
   - `fixed::FeeRule::non_standard`. Using a fixed fee may result in a transaction

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -20,6 +20,8 @@ and this library adheres to Rust's notion of
     ZIP 317 fee, use `zip317::FeeRule::standard()`. To preserve the current
     (deprecated) behaviour, use `fixed::FeeRule::non_standard(zip317::MINIMUM_FEE)`,
     but note that this is likely to result in transactions that cannot be mined.
+  - `StandardFeeRule::{PreZip313,Zip313}`. These also are likely to result in
+    transactions that cannot be mined.
 
 ## [0.19.0] - 2024-10-02
 

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -7,6 +7,20 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Deprecated
+- `zcash_primitives::transaction::fees`:
+  - `fixed::FeeRule::non_standard`. Using a fixed fee may result in a transaction
+    that cannot be mined on the current Zcash network. To calculate the ZIP 317 fee,
+    use `zip317::FeeRule::standard()`.
+
+### Removed
+- `zcash_primitives::transaction::fees`:
+  - `fixed::FeeRule::standard`. This constructor was misleadingly named: using a
+    fixed fee does not conform to any current Zcash standard. To calculate the
+    ZIP 317 fee, use `zip317::FeeRule::standard()`. To preserve the current
+    (deprecated) behaviour, use `fixed::FeeRule::non_standard(zip317::MINIMUM_FEE)`,
+    but note that this is likely to result in transactions that cannot be mined.
+
 ## [0.19.0] - 2024-10-02
 
 ### Changed

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -883,7 +883,7 @@ mod testing {
             self,
             prover::mock::{MockOutputProver, MockSpendProver},
         },
-        transaction::fees::fixed,
+        transaction::fees::{fixed, zip317::MINIMUM_FEE},
     };
 
     impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<'a, P, U> {
@@ -910,12 +910,12 @@ mod testing {
                 }
             }
 
-            #[allow(deprecated)]
             self.build(
                 FakeCryptoRng(rng),
                 &MockSpendProver,
                 &MockOutputProver,
-                &fixed::FeeRule::standard(),
+                #[allow(deprecated)]
+                &fixed::FeeRule::non_standard(MINIMUM_FEE),
             )
         }
     }

--- a/zcash_primitives/src/transaction/fees.rs
+++ b/zcash_primitives/src/transaction/fees.rs
@@ -62,14 +62,6 @@ pub trait FutureFeeRule: FeeRule {
 /// An enumeration of the standard fee rules supported by the wallet.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StandardFeeRule {
-    #[deprecated(
-        note = "Using this fee rule violates ZIP 317, and might cause transactions built with it to fail. Use `StandardFeeRule::Zip317` instead."
-    )]
-    PreZip313,
-    #[deprecated(
-        note = "Using this fee rule violates ZIP 317, and might cause transactions built with it to fail. Use `StandardFeeRule::Zip317` instead."
-    )]
-    Zip313,
     Zip317,
 }
 
@@ -86,10 +78,7 @@ impl FeeRule for StandardFeeRule {
         sapling_output_count: usize,
         orchard_action_count: usize,
     ) -> Result<NonNegativeAmount, Self::Error> {
-        #[allow(deprecated)]
         match self {
-            Self::PreZip313 => Ok(zip317::MINIMUM_FEE),
-            Self::Zip313 => Ok(NonNegativeAmount::const_from_u64(1000)),
             Self::Zip317 => zip317::FeeRule::standard().fee_required(
                 params,
                 target_height,

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,7 +1,7 @@
 use crate::{
     consensus::{self, BlockHeight},
     transaction::components::amount::NonNegativeAmount,
-    transaction::fees::{transparent, zip317},
+    transaction::fees::transparent,
 };
 
 #[cfg(zcash_unstable = "zfuture")]
@@ -16,27 +16,12 @@ pub struct FeeRule {
 
 impl FeeRule {
     /// Creates a new nonstandard fixed fee rule with the specified fixed fee.
+    #[deprecated(
+        note = "Using a fixed fee may result in a transaction that cannot be mined. \
+                To calculate the ZIP 317 fee, use `transaction::fees::zip317::FeeRule::standard()`."
+    )]
     pub fn non_standard(fixed_fee: NonNegativeAmount) -> Self {
         Self { fixed_fee }
-    }
-
-    /// Creates a new fixed fee rule with the minimum possible [ZIP 317] fee,
-    /// i.e. 10000 zatoshis.
-    ///
-    /// Note that using a fixed fee is not compliant with [ZIP 317]; consider
-    /// using [`zcash_primitives::transaction::fees::zip317::FeeRule::standard()`]
-    /// instead.
-    ///
-    /// [`zcash_primitives::transaction::fees::zip317::FeeRule::standard()`]: crate::transaction::fees::zip317::FeeRule::standard
-    /// [ZIP 317]: https://zips.z.cash/zip-0317
-    #[deprecated(
-        since = "0.12.0",
-        note = "To calculate the ZIP 317 fee, use `transaction::fees::zip317::FeeRule::standard()`. For a fixed fee, use the `non_standard` constructor."
-    )]
-    pub fn standard() -> Self {
-        Self {
-            fixed_fee: zip317::MINIMUM_FEE,
-        }
     }
 
     /// Returns the fixed fee amount which this rule was configured.

--- a/zcash_primitives/src/transaction/fees/fixed.rs
+++ b/zcash_primitives/src/transaction/fees/fixed.rs
@@ -1,3 +1,7 @@
+use std::convert::Infallible;
+
+use zcash_protocol::value::BalanceError;
+
 use crate::{
     consensus::{self, BlockHeight},
     transaction::components::amount::NonNegativeAmount,
@@ -31,7 +35,8 @@ impl FeeRule {
 }
 
 impl super::FeeRule for FeeRule {
-    type Error = std::convert::Infallible;
+    type Error = Infallible;
+    type FeeRuleOrBalanceError = BalanceError;
 
     fn fee_required<P: consensus::Parameters>(
         &self,
@@ -44,6 +49,18 @@ impl super::FeeRule for FeeRule {
         _orchard_action_count: usize,
     ) -> Result<NonNegativeAmount, Self::Error> {
         Ok(self.fixed_fee)
+    }
+
+    fn default_dust_threshold(&self) -> NonNegativeAmount {
+        self.fixed_fee
+    }
+
+    fn marginal_fee(&self) -> NonNegativeAmount {
+        NonNegativeAmount::ZERO
+    }
+
+    fn grace_actions(&self) -> usize {
+        0
     }
 }
 

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -83,7 +83,7 @@ impl FeeRule {
                  || p2pkh_standard_input_size > P2PKH_STANDARD_INPUT_SIZE \
                  || p2pkh_standard_output_size > P2PKH_STANDARD_OUTPUT_SIZE` \
                 violates ZIP 317, and might cause transactions built with it to fail. \
-                This API is likely to be removed. Use `[FeeRule::standard]` instead."
+                This API is likely to be removed. Use [`FeeRule::standard`] instead."
     )]
     pub fn non_standard(
         marginal_fee: NonNegativeAmount,
@@ -103,14 +103,6 @@ impl FeeRule {
         }
     }
 
-    /// Returns the ZIP 317 marginal fee.
-    pub fn marginal_fee(&self) -> NonNegativeAmount {
-        self.marginal_fee
-    }
-    /// Returns the ZIP 317 number of grace actions
-    pub fn grace_actions(&self) -> usize {
-        self.grace_actions
-    }
     /// Returns the ZIP 317 standard P2PKH input size
     pub fn p2pkh_standard_input_size(&self) -> usize {
         self.p2pkh_standard_input_size
@@ -152,6 +144,7 @@ impl std::fmt::Display for FeeError {
 
 impl super::FeeRule for FeeRule {
     type Error = FeeError;
+    type FeeRuleOrBalanceError = FeeError;
 
     fn fee_required<P: consensus::Parameters>(
         &self,
@@ -192,5 +185,17 @@ impl super::FeeRule for FeeRule {
 
         (self.marginal_fee * max(self.grace_actions, logical_actions))
             .ok_or_else(|| BalanceError::Overflow.into())
+    }
+
+    fn default_dust_threshold(&self) -> NonNegativeAmount {
+        self.marginal_fee
+    }
+
+    fn marginal_fee(&self) -> NonNegativeAmount {
+        self.marginal_fee
+    }
+
+    fn grace_actions(&self) -> usize {
+        self.grace_actions
     }
 }


### PR DESCRIPTION
* Remove `fixed::FeeRule::standard` (which was misleadingly named because fixed fees are not standard).
* Deprecate `fixed::FeeRule::non_standard`.
* Remove `zcash_primitives::transaction::fees::StandardFeeRule::{PreZip313,Zip313}`.
* Rename `zcash_client_backend::proto::ProposalDecodingError::FeeRuleNotSpecified` to `FeeRuleNotSupported` and use it to report attempted use of the removed rules.
* Refactor change strategies so that we can use a `CommonChangeStrategy` that is generic in the fee rule. This should simplify future generalizations of the change strategy.
* Undo the changes to `{fixed,standard,zip317}::SingleOutputChangeStrategy`, and deprecate those types' `new` constructors. They are now implemented as trivial wrappers over `CommonChangeStrategy`.